### PR TITLE
Rename scheduling flags

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -58,7 +58,7 @@ macro_rules! rustler_export_nifs {
     };
 
     (internal, ($nif_name:expr, $nif_arity:expr, $nif_fun:path)) => {
-        rustler_export_nifs!(internal, ($nif_name, $nif_arity, $nif_fun, rustler::schedule::NifScheduleFlags::NORMAL))
+        rustler_export_nifs!(internal, ($nif_name, $nif_arity, $nif_fun, rustler::schedule::NifScheduleFlags::Normal))
     };
     (internal, ($nif_name:expr, $nif_arity:expr, $nif_fun:path, $nif_flag:expr)) => {
         rustler::wrapper::nif_interface::DEF_NIF_FUNC {

--- a/src/export.rs
+++ b/src/export.rs
@@ -2,11 +2,11 @@
 ///
 /// This should be called exactly once in every NIF library. It will wrap and export the given rust
 /// functions into the Erlang module.
-/// 
+///
 /// The first argument is a string specifying what Erlang/Elixir module you want the function
 /// exported into. In Erlang this will simply be the atom you named your module. In Elixir, all
 /// modules are prefixed with `Elixir.<module path>`
-/// 
+///
 /// The second argument is a list of 3-tuples. Each tuple contains information on a single exported
 /// NIF function. The first tuple item is the name you want to export the function into, the second
 /// is the arity (number of arguments) of the exported function. The third argument is a
@@ -58,7 +58,7 @@ macro_rules! rustler_export_nifs {
     };
 
     (internal, ($nif_name:expr, $nif_arity:expr, $nif_fun:path)) => {
-        rustler_export_nifs!(internal, ($nif_name, $nif_arity, $nif_fun, rustler::wrapper::nif_interface::ErlNifTaskFlags::ERL_NIF_NORMAL_JOB))
+        rustler_export_nifs!(internal, ($nif_name, $nif_arity, $nif_fun, rustler::schedule::NifScheduleFlags::NORMAL))
     };
     (internal, ($nif_name:expr, $nif_arity:expr, $nif_fun:path, $nif_flag:expr)) => {
         rustler::wrapper::nif_interface::DEF_NIF_FUNC {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,6 +1,12 @@
 use super::NifEnv;
 use super::wrapper::nif_interface::enif_consume_timeslice;
 
+pub enum NifScheduleFlags {
+    NORMAL = 0,
+    DIRTY_CPU = 1,
+    DIRTY_IO = 2,
+}
+
 pub fn consume_timeslice<'a>(env: &'a NifEnv, percent: i32) -> bool {
     let success = unsafe { enif_consume_timeslice(env.as_c_arg(), percent) };
     success == 1

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -2,9 +2,9 @@ use super::NifEnv;
 use super::wrapper::nif_interface::enif_consume_timeslice;
 
 pub enum NifScheduleFlags {
-    NORMAL = 0,
-    DIRTY_CPU = 1,
-    DIRTY_IO = 2,
+    Normal = 0,
+    DirtyCpu = 1,
+    DirtyIo = 2,
 }
 
 pub fn consume_timeslice<'a>(env: &'a NifEnv, percent: i32) -> bool {


### PR DESCRIPTION
This PR gives more ergnomic use of NIF scheduling flags.

```rust
use rustler::schedule::NifScheduleFlags::*;

rustler_export_nifs! {
    "Elixir.MyNifModule",
    [("normal_nif", 1, normal_nif),
     ("dirty_cpu_nif", 1, dirty_cpu_nif, DirtyCpu),
     ("dirty_io_nif", 1, dirty_io_nif, DirtyIo)],
    Some(load)
}
```