### PR TITLE
`rustler::thread::spawn` for threaded NIFs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod resource;
 
 pub mod dynamic;
 pub mod schedule;
+pub mod thread;
 
 mod export;
 
@@ -60,6 +61,15 @@ pub struct NifEnv {
 impl NifEnv {
     pub fn as_c_arg(&self) -> NIF_ENV {
         self.env
+    }
+
+    /// Convenience method for building a tuple `{error, Reason}`.
+    pub fn error_tuple<'a, T>(&'a self, reason: T) -> NifTerm<'a>
+        where T: NifEncoder
+    {
+        let error = types::atom::get_atom_init("error").to_term(self);
+        let reason_term = reason.encode(self);
+        types::tuple::make_tuple(self, &[error, reason_term])
     }
 }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,0 +1,58 @@
+use ::{ NifEnv, NifTerm, NifEncoder };
+use ::wrapper::nif_interface::{ self, ErlNifPid };
+use ::types::atom;
+use std::mem;
+use std::thread;
+use std::panic;
+
+/// Return the calling process's pid.
+fn caller(caller_env: &NifEnv) -> ErlNifPid {
+    let mut pid: ErlNifPid = unsafe { mem::uninitialized() };
+    unsafe {
+        nif_interface::enif_self(caller_env.as_c_arg(), &mut pid);
+    }
+    pid
+}
+
+/// Implements threaded NIFs.
+///
+/// This spawns a thread that calls the given closure `thread_fn`. When the closure returns, the
+/// thread sends its return value back to the calling process.  If the closure panics, an `{error,
+/// Reason}` tuple is sent instead.
+///
+/// Note that the thread creates a new `NifEnv` and passes it to the closure, so the closure
+/// runs under a separate environment, not under `env`.
+///
+pub fn spawn<'a, F>(env: &'a NifEnv, thread_fn: F)
+    where F: for<'b> FnOnce(&'b NifEnv) -> NifTerm<'b> + Send + panic::UnwindSafe + 'static,
+{
+    let pid = caller(env);
+    thread::spawn(move || {
+        let env = NifEnv {
+            env: unsafe { nif_interface::enif_alloc_env() }
+        };
+
+        let message = match panic::catch_unwind(|| thread_fn(&env)) {
+            Ok(term) => term,
+            Err(err) => {
+                // Try to get an error message from Rust.
+                let reason =
+                    if let Some(string) = err.downcast_ref::<String>() {
+                        string.encode(&env)
+                    } else if let Some(&s) = err.downcast_ref::<&'static str>() {
+                        s.encode(&env)
+                    } else {
+                        atom::get_atom_init("nif_panic").to_term(&env)
+                    };
+                env.error_tuple(reason)
+            }
+        };
+
+        unsafe {
+            nif_interface::enif_send(env.as_c_arg(),
+                                     &pid,
+                                     env.as_c_arg(),
+                                     message.as_c_arg());
+        }
+    });
+}

--- a/src/wrapper/nif_interface.rs
+++ b/src/wrapper/nif_interface.rs
@@ -193,6 +193,8 @@ pub unsafe fn enif_keep_resource(obj: NIF_RESOURCE_HANDLE) {
 pub use self::erlang_nif_sys::{
     ErlNifMapIterator,
     ErlNifMapIteratorEntry,
+    ErlNifPid,
+    enif_self,
     enif_map_iterator_create,
     enif_map_iterator_get_pair,
     enif_map_iterator_next,

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -32,4 +32,7 @@ defmodule RustlerTest do
   def make_shorter_subbinary(_), do: err
 
   def atom_to_string(_), do: err
+
+  def threaded_fac(_), do: err
+  def threaded_sleep(_), do: err
 end

--- a/test/src/lib.in.rs
+++ b/test/src/lib.in.rs
@@ -18,6 +18,9 @@ use test_binary::make_shorter_subbinary;
 mod test_atom;
 use test_atom::{atom_to_string};
 
+mod test_thread;
+use test_thread::{threaded_fac, threaded_sleep};
+
 rustler_export_nifs!(
     "Elixir.RustlerTest",
     [("add_u32", 2, add_u32),
@@ -32,7 +35,9 @@ rustler_export_nifs!(
      ("resource_set_integer_field", 2, resource_set_integer_field),
      ("resource_get_integer_field", 1, resource_get_integer_field),
      ("atom_to_string", 1, atom_to_string),
-     ("make_shorter_subbinary", 1, make_shorter_subbinary)],
+     ("make_shorter_subbinary", 1, make_shorter_subbinary),
+     ("threaded_fac", 1, threaded_fac),
+     ("threaded_sleep", 1, threaded_sleep)],
     Some(on_load)
 );
 

--- a/test/src/test_thread.rs
+++ b/test/src/test_thread.rs
@@ -1,0 +1,33 @@
+use rustler::{ NifEnv, NifTerm, NifResult, NifEncoder, NifDecoder };
+use rustler::thread;
+use std;
+
+pub fn threaded_fac<'a>(env: &'a NifEnv, args: &Vec<NifTerm>) -> NifResult<NifTerm<'a>> {
+    // Multiply two numbers; panic on overflow. In Rust, the `*` operator wraps (rather than
+    // panicking) in release builds. A test depends on this panicking, so we make sure it panics in
+    // all builds. The test also checks the panic message.
+    fn mul(a: u64, b: u64) -> u64 {
+        a.checked_mul(b).expect("threaded_fac: integer overflow")
+    }
+
+    let n: u64 = args[0].decode()?;
+    thread::spawn(env, move |thread_env| {
+        let result = (1 .. n + 1).fold(1, mul);
+        result.encode(thread_env)
+    });
+
+    Ok("spawned".encode(env))
+}
+
+pub fn threaded_sleep<'a>(env: &'a NifEnv, args: &Vec<NifTerm>) -> NifResult<NifTerm<'a>> {
+    let msec: u64 = args[0].decode()?;
+
+    let q = msec / 1000;
+    let r = (msec % 1000) as u32;
+    thread::spawn(env, move |thread_env| {
+        std::thread::sleep(std::time::Duration::new(q as u64, r * 1_000_000));
+        msec.encode(thread_env)
+    });
+
+    Ok("spawned".encode(env))
+}

--- a/test/test/thread_test.exs
+++ b/test/test/thread_test.exs
@@ -1,0 +1,51 @@
+defmodule RustlerTest.ThreadTest do
+  use ExUnit.Case, async: true
+
+  test "simple threaded nif" do
+    RustlerTest.threaded_fac 19
+    receive do
+      x -> assert x == 121645100408832000
+    end
+  end
+
+  test "sleeping nif" do
+    RustlerTest.threaded_sleep 200
+    receive do
+      _ -> raise :timeout_expected
+    after 100 ->
+        nil
+    end
+
+    receive do
+      x -> assert x == 200
+    after 1000 ->
+        raise :message_expected
+    end
+  end
+
+  test "many threads" do
+    # Spawn 50 threads.
+    times = Enum.map(1..50, fn (x) -> x * 10 end)
+    Enum.map(times, &RustlerTest.threaded_sleep/1)
+
+    # Wait for them all to respond.
+    results = Enum.map(times, fn (_) ->
+      receive do
+        y -> y
+      after 1000 ->
+          :timeout
+      end
+    end)
+
+    # The OS scheduler guarantees virtually nothing about sleep().
+    # Answers may arrive out of order.
+    assert Enum.sort(results) == times
+  end
+
+  test "thread panic" do
+    RustlerTest.threaded_fac 100  # overflows u64 and panics
+    receive do
+      msg -> assert msg == {:error, "threaded_fac: integer overflow"}
+    end
+  end
+end


### PR DESCRIPTION
This also adds a public `env.error_tuple(reason)` method, just because it's handy.