### PR TITLE
Make function calls to zero-arity functions explicit

### DIFF
--- a/rustler_mix/lib/rustler/compiler/rustup.ex
+++ b/rustler_mix/lib/rustler/compiler/rustup.ex
@@ -3,17 +3,17 @@ defmodule Rustler.Compiler.Rustup do
   def rustup_binary, do: System.get_env("RUSTUP_BINARY") || "rustup"
 
   def version do
-    multirust_exec = System.find_executable(rustup_binary)
+    multirust_exec = System.find_executable(rustup_binary())
     if multirust_exec == nil do
       :none
     else
-      {version, 0} = System.cmd(rustup_binary, ["--version"])
+      {version, 0} = System.cmd(rustup_binary(), ["--version"])
       {:ok, version}
     end
   end
 
   def version_installed?(version) do
-    {_resp, return} = System.cmd(rustup_binary, ["run", version, "rustc", "--version"])
+    {_resp, return} = System.cmd(rustup_binary(), ["run", version, "rustc", "--version"])
     case return do
       0 -> true
       _ -> false
@@ -28,12 +28,12 @@ defmodule Rustler.Compiler.Rustup do
   #end
 
   def install_toolchain(version) do
-    {_resp, 0} = System.cmd(rustup_binary, ["install", version],
+    {_resp, 0} = System.cmd(rustup_binary(), ["install", version],
                             into: IO.stream(:stdio, :line))
   end
 
   def compile_with(path, version, args \\ [], env \\ [], into \\ "") do
-    System.cmd(rustup_binary, ["run", version, "cargo", "build" | args],
+    System.cmd(rustup_binary(), ["run", version, "cargo", "build" | args],
                cd: path, into: into, env: env)
   end
 

--- a/rustler_mix/lib/task_compile.ex
+++ b/rustler_mix/lib/task_compile.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Compile.Rustler do
   end
 
   def nif_lib_dir do
-    path = Path.join(priv_path, "rustler")
+    path = Path.join(priv_path(), "rustler")
     File.mkdir_p!(path)
     path
   end
@@ -61,9 +61,9 @@ defmodule Mix.Tasks.Compile.Rustler do
       {_, code} -> raise "Rust NIF compile error (rustc exit code #{code})"
     end
 
-    {src_ext, dst_ext} = dll_extension
+    {src_ext, dst_ext} = dll_extension()
     compiled_lib = "#{target_dir}/#{build_mode}/lib#{lib_name}.#{src_ext}"
-    destination_lib = "#{nif_lib_dir}/lib#{lib_name}.#{dst_ext}"
+    destination_lib = "#{nif_lib_dir()}/lib#{lib_name}.#{dst_ext}"
     File.cp!(compiled_lib, destination_lib)
   end
 

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -10,13 +10,13 @@ defmodule Rustler.Mixfile do
      name: "Rustler Mix",
      source_url: "https://github.com/hansihe/Rustler",
      homepage_url: "https://github.com/hansihe/Rustler",
-     deps: deps,
+     deps: deps(),
      docs: [
        extras: ["guides/Basics.md"],
        source_url_pattern: "https://github.com/hansihe/Rustler/blob/master/rustler_mix/%{path}#L%{line}"
      ],
-     package: package,
-     description: description]
+     package: package(),
+     description: description()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
There was a warning introduced in Elixir 1.4 which complained about
zero-arity function calls without parentheses roughly like the
following:

> ```
> warning: variable "foo" does not exist and is beeing expanded to "foo()", please use parentheses to remove the ambiguity or change the variable name
> ```