### PR TITLE
`OwnedEnv`

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -2,7 +2,25 @@ use ::{ NifEnv, NifTerm };
 use wrapper::copy_term;
 use wrapper::nif_interface::{ self, NIF_ENV, NIF_TERM };
 pub use wrapper::nif_interface::ErlNifPid;
+use std::mem;
 use std::sync::{Arc, Weak};
+
+impl<'a> NifEnv<'a> {
+    /// Return the calling process's pid.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this environment is process-independent.  (The only way to get such an
+    /// environment is to use `OwnedEnv`.  The `NifEnv` that Rustler passes to NIFs when they're
+    /// called is always associated with the calling Erlang process.)
+    pub fn pid(self) -> ErlNifPid {
+        let mut pid: ErlNifPid = unsafe { mem::uninitialized() };
+        if unsafe { nif_interface::enif_self(self.as_c_arg(), &mut pid) }.is_null() {
+            panic!("environment is process-independent");
+        }
+        pid
+    }
+}
 
 
 // Helper function used by save() and load().

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,17 +1,46 @@
 use ::{ NifEnv, NifTerm };
-use wrapper::nif_interface::{ self, NIF_ENV, ErlNifPid };
-use std::mem;
+use wrapper::copy_term;
+use wrapper::nif_interface::{ self, NIF_ENV, NIF_TERM };
+pub use wrapper::nif_interface::ErlNifPid;
+use std::sync::{Arc, Weak};
 
+
+// Helper function used by save() and load().
+fn nif_term_into_env<'a>(term: NIF_TERM, src_env: NIF_ENV, dest_env: NIF_ENV) -> NIF_TERM {
+    if src_env == dest_env {
+        term
+    } else {
+        copy_term(dest_env, term)
+    }
+}
+
+
+/// A process-independent environment.
+///
+/// An owned environment is a place where Erlang terms can be created outside of a NIF call. Rust
+/// code can use an owned environment to build a message and send it to an Erlang process.
+///
+///     use rustler::env::{OwnedEnv, ErlNifPid};
+///     use rustler::NifEncoder;
+///
+///     fn send_string_to_pid(data: &str, pid: ErlNifPid) {
+///         let mut msg_env = OwnedEnv::new();
+///         msg_env.send(pid, |env| data.encode(env));
+///     }
+///
+/// There's no way to run Erlang code in an owned environment. It's not a process. It's just a
+/// workspace for building terms.
 pub struct OwnedEnv {
-    env: NIF_ENV
+    env: Arc<NIF_ENV>
 }
 
 unsafe impl Send for OwnedEnv {}
 
 impl OwnedEnv {
+    /// Allocates a new process-independent environment.
     pub fn new() -> OwnedEnv {
         OwnedEnv {
-            env: unsafe { nif_interface::enif_alloc_env() }
+            env: Arc::new(unsafe { nif_interface::enif_alloc_env() })
         }
     }
 
@@ -20,7 +49,7 @@ impl OwnedEnv {
         where F: for<'a> FnOnce(NifEnv<'a>) -> R
     {
         let env_lifetime = ();
-        let env = unsafe { NifEnv::new(&env_lifetime, self.env) };
+        let env = unsafe { NifEnv::new(&env_lifetime, *self.env) };
         closure(env)
     }
 
@@ -32,25 +61,98 @@ impl OwnedEnv {
         where F: for<'a> FnOnce(NifEnv<'a>) -> NifTerm<'a>
     {
         let env_lifetime = ();
-        let env = unsafe { NifEnv::new(&env_lifetime, self.env) };
+        let c_env = *self.env;
+        let env = unsafe { NifEnv::new(&env_lifetime, c_env) };
         let message = closure(env);
+
+        self.env = Arc::new(c_env);
         unsafe {
-            nif_interface::enif_send(self.env, &recipient, self.env, message.as_c_arg());
+            nif_interface::enif_send(*self.env, &recipient, *self.env, message.as_c_arg());
         }
     }
 
     /// Free all terms in this environment and clear it for reuse.
     ///
+    /// This invalidates `SavedTerm`s that were saved in this environment;
+    /// if you later try to `.load()` one, you'll get a panic.
+    ///
     /// Unless you call this method after a call to `run()`, all terms created within the
     /// environment hang around in memory until the `OwnedEnv` is dropped: garbage collection does
     /// not continually happen as needed in a NIF environment.
     pub fn clear(&mut self) {
-        unsafe { nif_interface::enif_clear_env(self.env); }
+        let c_env = *self.env;
+        self.env = Arc::new(c_env);
+        unsafe { nif_interface::enif_clear_env(c_env); }
+    }
+
+    /// Save a term for use in a later call to `.run()` or `.send()`.
+    ///
+    /// For your safety, Rust doesn't let you save `NifTerm` values from one `.run()` call to a
+    /// later `.run()` call. If you try, it'll complain about lifetimes.
+    ///
+    /// `.save()` offers a way to do this. For example, maybe you'd like to copy a term from the
+    /// caller into an `OwnedEnv`, then use that term on another thread.
+    ///
+    ///     # use rustler::{ NifEnv, NifTerm };
+    ///     use rustler::env::OwnedEnv;
+    ///     use std::thread;
+    ///
+    ///     fn thread_example<'a>(env: NifEnv<'a>, term: NifTerm<'a>) {
+    ///         // Copy `term` into a new OwnedEnv, for use on another thread.
+    ///         let mut thread_env = OwnedEnv::new();
+    ///         let saved_term = thread_env.save(term);
+    ///
+    ///         thread::spawn(move || {
+    ///             // Now run some code on the thread, using the saved term.
+    ///             thread_env.run(|env| {
+    ///                 let term = saved_term.load(env);
+    ///                 //... do stuff with term ...
+    ///             });
+    ///         });
+    ///     }
+    ///
+    /// **Note: There is no way to save terms across `OwnedEnv::send()` or `clear()`.**
+    /// If you try, the `.load()` call will panic.
+    pub fn save<'a>(&self, term: NifTerm<'a>) -> SavedTerm {
+        SavedTerm {
+            term: nif_term_into_env(term.as_c_arg(), term.get_env().as_c_arg(), *self.env),
+            env_generation: Arc::downgrade(&self.env),
+        }
     }
 }
 
 impl Drop for OwnedEnv {
     fn drop(&mut self) {
-        unsafe { nif_interface::enif_free_env(self.env); }
+        unsafe { nif_interface::enif_free_env(*self.env); }
+    }
+}
+
+/// A term that was created in an `OwnedEnv` and saved for later use.
+///
+/// These are created by calling `OwnedEnv::save()`. See that method's documentation for an
+/// example.
+#[derive(Clone)]
+pub struct SavedTerm {
+    env_generation: Weak<NIF_ENV>,
+    term: NIF_TERM,
+}
+
+unsafe impl Send for SavedTerm {}
+
+impl SavedTerm {
+    /// Load this saved term into any `NifEnv`.
+    ///
+    /// If `env` isn't in the same `OwnedEnv` where this term was saved, the term will be copied.
+    ///
+    /// # Panics
+    /// Panics if the `OwnedEnv` where this term was saved has been cleared or dropped.
+    pub fn load<'a>(&self, env: NifEnv<'a>) -> NifTerm<'a> {
+        // Check that the saved term is still valid.
+        match self.env_generation.upgrade() {
+            None =>
+                panic!("term is from a cleared or dropped OwnedEnv"),
+            Some(env_arc) =>
+                NifTerm::new(env, nif_term_into_env(self.term, *env_arc, env.as_c_arg()))
+        }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,56 @@
+use ::{ NifEnv, NifTerm };
+use wrapper::nif_interface::{ self, NIF_ENV, ErlNifPid };
+use std::mem;
+
+pub struct OwnedEnv {
+    env: NIF_ENV
+}
+
+unsafe impl Send for OwnedEnv {}
+
+impl OwnedEnv {
+    pub fn new() -> OwnedEnv {
+        OwnedEnv {
+            env: unsafe { nif_interface::enif_alloc_env() }
+        }
+    }
+
+    /// Run some code in this environment.
+    pub fn run<F, R>(&self, closure: F) -> R
+        where F: for<'a> FnOnce(NifEnv<'a>) -> R
+    {
+        let env_lifetime = ();
+        let env = unsafe { NifEnv::new(&env_lifetime, self.env) };
+        closure(env)
+    }
+
+    /// Run a closure that produces a term, then send the term to another process.
+    ///
+    /// After the closure runs and the message is sent, the environment is cleared as though by
+    /// calling the `.clear()` method.
+    pub fn send<F>(&mut self, recipient: ErlNifPid, closure: F)
+        where F: for<'a> FnOnce(NifEnv<'a>) -> NifTerm<'a>
+    {
+        let env_lifetime = ();
+        let env = unsafe { NifEnv::new(&env_lifetime, self.env) };
+        let message = closure(env);
+        unsafe {
+            nif_interface::enif_send(self.env, &recipient, self.env, message.as_c_arg());
+        }
+    }
+
+    /// Free all terms in this environment and clear it for reuse.
+    ///
+    /// Unless you call this method after a call to `run()`, all terms created within the
+    /// environment hang around in memory until the `OwnedEnv` is dropped: garbage collection does
+    /// not continually happen as needed in a NIF environment.
+    pub fn clear(&mut self) {
+        unsafe { nif_interface::enif_clear_env(self.env); }
+    }
+}
+
+impl Drop for OwnedEnv {
+    fn drop(&mut self) {
+        unsafe { nif_interface::enif_free_env(self.env); }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod resource;
 
 pub mod dynamic;
 pub mod schedule;
+pub mod env;
 pub mod thread;
 
 mod export;
@@ -76,6 +77,22 @@ impl<'a, 'b> PartialEq<NifEnv<'b>> for NifEnv<'a> {
 }
 
 impl<'a> NifEnv<'a> {
+    /// Create a new NifEnv. For the `_lifetime_marker` argument, pass a
+    /// reference to any local variable that has its own lifetime, different
+    /// from all other `NifEnv` values. The purpose of the argument is to make
+    /// it easier to know for sure that the `NifEnv` you're creating has a
+    /// unique lifetime (i.e. that you're following the most important safety
+    /// rule of Rustler).
+    ///
+    /// # Unsafe
+    /// Don't create multiple `NifEnv`s with the same lifetime.
+    unsafe fn new<T>(_lifetime_marker: &'a T, env: NIF_ENV) -> NifEnv<'a> {
+        NifEnv {
+            env: env,
+            id: PhantomData
+        }
+    }
+
     pub fn as_c_arg(&self) -> NIF_ENV {
         self.env
     }

--- a/src/wrapper/nif_interface.rs
+++ b/src/wrapper/nif_interface.rs
@@ -194,6 +194,8 @@ pub use self::erlang_nif_sys::{
     ErlNifMapIterator,
     ErlNifMapIteratorEntry,
     ErlNifPid,
+    enif_clear_env,
+    enif_free_env,
     enif_self,
     enif_map_iterator_create,
     enif_map_iterator_get_pair,

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -35,4 +35,6 @@ defmodule RustlerTest do
 
   def threaded_fac(_), do: err
   def threaded_sleep(_), do: err
+
+  def sublists(_), do: err
 end

--- a/test/src/lib.in.rs
+++ b/test/src/lib.in.rs
@@ -21,6 +21,9 @@ use test_atom::{atom_to_string};
 mod test_thread;
 use test_thread::{threaded_fac, threaded_sleep};
 
+mod test_env;
+use test_env::{sublists};
+
 rustler_export_nifs!(
     "Elixir.RustlerTest",
     [("add_u32", 2, add_u32),
@@ -37,7 +40,8 @@ rustler_export_nifs!(
      ("atom_to_string", 1, atom_to_string),
      ("make_shorter_subbinary", 1, make_shorter_subbinary),
      ("threaded_fac", 1, threaded_fac),
-     ("threaded_sleep", 1, threaded_sleep)],
+     ("threaded_sleep", 1, threaded_sleep),
+     ("sublists", 1, sublists)],
     Some(on_load)
 );
 

--- a/test/src/test_env.rs
+++ b/test/src/test_env.rs
@@ -1,0 +1,42 @@
+use rustler::{NifEnv, NifTerm, NifResult, NifEncoder};
+use rustler::env::{OwnedEnv, SavedTerm};
+use rustler::types::list::NifListIterator;
+use rustler::types::atom;
+use std::thread;
+
+pub fn sublists<'a>(env: NifEnv<'a>, args: &Vec<NifTerm<'a>>) -> NifResult<NifTerm<'a>> {
+    let pid = env.pid();
+    let mut my_env = OwnedEnv::new();
+    let saved_reversed_list = my_env.run(|env| -> NifResult<SavedTerm> {
+        let list_arg = args[0].in_env(env);
+        Ok(my_env.save(list_arg.list_reverse()?))
+    })?;
+
+    thread::spawn(move || {
+        my_env.send(pid, |env| {
+            let result: NifResult<NifTerm> = (|| {
+                let reversed_list = saved_reversed_list.load(env);
+                let iter: NifListIterator = try!(reversed_list.decode());
+
+                let empty_list = Vec::<NifTerm>::new().encode(env);
+                let mut all_sublists = vec![empty_list];
+
+                for element in iter {
+                    for i in 0 .. all_sublists.len() {
+                        let new_list = all_sublists[i].list_prepend(element);
+                        all_sublists.push(new_list);
+                    }
+                }
+
+                Ok(all_sublists.encode(env))
+            })();
+
+            match result {
+                Err(_err) => env.error_tuple("test failed".encode(env)),
+                Ok(term) => term
+            }
+        });
+    });
+
+    Ok(atom::get_atom_init("ok").to_term(env))
+}

--- a/test/src/test_thread.rs
+++ b/test/src/test_thread.rs
@@ -1,4 +1,4 @@
-use rustler::{ NifEnv, NifTerm, NifResult, NifEncoder, NifDecoder };
+use rustler::{ NifEnv, NifTerm, NifResult, NifEncoder };
 use rustler::thread;
 use std;
 

--- a/test/test/env_test.exs
+++ b/test/test/env_test.exs
@@ -1,0 +1,25 @@
+defmodule RustlerTest.EnvTest do
+  use ExUnit.Case, async: true
+
+  test "owned environments" do
+    shop_menu = [
+      {:spaniel, 34},
+      {:ring_of_power, 75},
+      {:rope, 4}
+    ]
+    RustlerTest.sublists shop_menu
+    receive do
+      x ->
+        assert x == [
+          [],
+          [{:rope, 4}],
+          [{:ring_of_power, 75}],
+          [{:ring_of_power, 75}, {:rope, 4}],
+          [{:spaniel, 34}],
+          [{:spaniel, 34}, {:rope, 4}],
+          [{:spaniel, 34}, {:ring_of_power, 75}],
+          [{:spaniel, 34}, {:ring_of_power, 75}, {:rope, 4}]
+        ]
+    end
+  end
+end


### PR DESCRIPTION
Exposes safe APIs for `enif_self`, `enif_alloc_env`, the main `enif_send` use case, `enif_clear_env`, `enif_free_env`.