### PR TITLE
`NifPid` and `env.send(pid, message)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Hansihe <me@hansihe.com>"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-erlang_nif-sys = ">=0.5"
+erlang_nif-sys = ">=0.5.4"
 lazy_static = "0.1.*"

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,6 +3,17 @@ use ::wrapper::nif_interface::{ self, NIF_ENV, NIF_TERM };
 use ::types::pid::NifPid;
 use std::sync::{Arc, Weak};
 
+impl<'a> NifEnv<'a> {
+    /// Send a message to a process.
+    pub fn send(self, pid: &NifPid, message: NifTerm<'a>) {
+        // Implementation note: As of ERTS 8.0 (Erlang/OTP 19), there is another way to do this:
+        // pass a null pointer to the `msg_env` parameter of `enif_send()`. That might be
+        // faster. For now, we copy the term into a process-independent environment, then send it.
+        OwnedEnv::new().send(pid, |env| message.in_env(env))
+    }
+}
+
+
 /// A process-independent environment.
 ///
 /// An owned environment is a place where Erlang terms can be created outside of a NIF call. Rust

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,36 +1,18 @@
 use ::{ NifEnv, NifTerm };
-use wrapper::nif_interface::{ self, NIF_ENV, NIF_TERM };
-pub use wrapper::nif_interface::ErlNifPid;
-use std::mem;
+use ::wrapper::nif_interface::{ self, NIF_ENV, NIF_TERM };
+use ::types::pid::NifPid;
 use std::sync::{Arc, Weak};
-
-impl<'a> NifEnv<'a> {
-    /// Return the calling process's pid.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this environment is process-independent.  (The only way to get such an
-    /// environment is to use `OwnedEnv`.  The `NifEnv` that Rustler passes to NIFs when they're
-    /// called is always associated with the calling Erlang process.)
-    pub fn pid(self) -> ErlNifPid {
-        let mut pid: ErlNifPid = unsafe { mem::uninitialized() };
-        if unsafe { nif_interface::enif_self(self.as_c_arg(), &mut pid) }.is_null() {
-            panic!("environment is process-independent");
-        }
-        pid
-    }
-}
-
 
 /// A process-independent environment.
 ///
 /// An owned environment is a place where Erlang terms can be created outside of a NIF call. Rust
 /// code can use an owned environment to build a message and send it to an Erlang process.
 ///
-///     use rustler::env::{OwnedEnv, ErlNifPid};
+///     use rustler::env::OwnedEnv;
+///     use rustler::types::pid::NifPid;
 ///     use rustler::NifEncoder;
 ///
-///     fn send_string_to_pid(data: &str, pid: ErlNifPid) {
+///     fn send_string_to_pid(data: &str, pid: &NifPid) {
 ///         let mut msg_env = OwnedEnv::new();
 ///         msg_env.send(pid, |env| data.encode(env));
 ///     }
@@ -64,7 +46,7 @@ impl OwnedEnv {
     ///
     /// After the closure runs and the message is sent, the environment is cleared as though by
     /// calling the `.clear()` method.
-    pub fn send<F>(&mut self, recipient: ErlNifPid, closure: F)
+    pub fn send<F>(&mut self, recipient: &NifPid, closure: F)
         where F: for<'a> FnOnce(NifEnv<'a>) -> NifTerm<'a>
     {
         let env_lifetime = ();
@@ -74,7 +56,7 @@ impl OwnedEnv {
 
         self.env = Arc::new(c_env);
         unsafe {
-            nif_interface::enif_send(*self.env, &recipient, *self.env, message.as_c_arg());
+            nif_interface::enif_send(*self.env, recipient.as_c_arg(), *self.env, message.as_c_arg());
         }
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -4,12 +4,22 @@ use ::types::atom::NifAtom;
 use std::thread;
 use std::panic;
 
+/// A `JobSpawner` is a value that can run Rust code on non-Erlang system threads.
+/// Abstracts away details of thread management for `spawn()`.
+///
+/// Note: Implementations of `spawn()` must call the closure on a thread that is **not** managed by
+/// the Erlang VM's scheduler. Otherwise, `rustler::thread::spawn()` would try to send a message
+/// from an `OwnedEnv` on an Erlang thread, which would panic.
 pub trait JobSpawner {
+    /// Run the given closure on another thread.
     fn spawn<F: FnOnce() + Send + panic::UnwindSafe + 'static>(job: F);
 }
 
+/// A `JobSpawner` that uses a separate system thread for each job.
 pub struct ThreadSpawner;
+
 impl JobSpawner for ThreadSpawner {
+    /// This delegates to `std::thread::spawn()`.
     fn spawn<F: FnOnce() + Send + panic::UnwindSafe + 'static>(job: F) {
         thread::spawn(job);
     }
@@ -30,7 +40,7 @@ pub fn spawn<'a, S, F>(env: NifEnv<'a>, thread_fn: F)
 {
     let pid = env.pid();
     S::spawn(move || {
-        OwnedEnv::new().send(&pid, |env| {
+        OwnedEnv::new().send_and_clear(&pid, |env| {
             match panic::catch_unwind(|| thread_fn(env)) {
                 Ok(term) => term,
                 Err(err) => {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -30,7 +30,7 @@ pub fn spawn<'a, S, F>(env: NifEnv<'a>, thread_fn: F)
 {
     let pid = env.pid();
     S::spawn(move || {
-        OwnedEnv::new().send(pid, |env| {
+        OwnedEnv::new().send(&pid, |env| {
             match panic::catch_unwind(|| thread_fn(env)) {
                 Ok(term) => term,
                 Err(err) => {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,6 +12,7 @@ pub mod map;
 pub mod primitive;
 pub mod string;
 pub mod tuple;
+pub mod pid;
 
 pub mod elixir_struct;
 

--- a/src/types/pid.rs
+++ b/src/types/pid.rs
@@ -1,0 +1,46 @@
+use ::{ NifEnv, NifTerm, NifError, NifResult, NifDecoder, NifEncoder };
+use ::wrapper::nif_interface::{ self, ErlNifPid };
+use ::wrapper::pid;
+use std::mem;
+
+#[derive(Clone)]
+pub struct NifPid {
+    c: ErlNifPid
+}
+
+impl NifPid {
+    pub fn as_c_arg(&self) -> &ErlNifPid {
+        &self.c
+    }
+}
+
+impl<'a> NifDecoder<'a> for NifPid {
+    fn decode(term: NifTerm<'a>) -> NifResult<NifPid> {
+        unsafe { pid::get_local_pid(term.get_env().as_c_arg(), term.as_c_arg()) }
+            .map(|pid| NifPid { c: pid })
+            .ok_or(NifError::BadArg)
+    }
+}
+
+impl NifEncoder for NifPid {
+    fn encode<'a>(&self, env: NifEnv<'a>) -> NifTerm<'a> {
+        unsafe { NifTerm::new(env, pid::make_pid(env.as_c_arg(), &self.c)) }
+    }
+}
+
+impl<'a> NifEnv<'a> {
+    /// Return the calling process's pid.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this environment is process-independent.  (The only way to get such an
+    /// environment is to use `OwnedEnv`.  The `NifEnv` that Rustler passes to NIFs when they're
+    /// called is always associated with the calling Erlang process.)
+    pub fn pid(self) -> NifPid {
+        let mut pid: ErlNifPid = unsafe { mem::uninitialized() };
+        if unsafe { nif_interface::enif_self(self.as_c_arg(), &mut pid) }.is_null() {
+            panic!("environment is process-independent");
+        }
+        NifPid { c: pid }
+    }
+}

--- a/src/wrapper/mod.rs
+++ b/src/wrapper/mod.rs
@@ -14,6 +14,7 @@ pub mod atom;
 pub mod exception;
 pub mod resource;
 pub mod list;
+pub mod pid;
 pub mod check;
 
 pub use self::nif_interface::enif_make_copy as copy_term;

--- a/src/wrapper/nif_interface.rs
+++ b/src/wrapper/nif_interface.rs
@@ -196,11 +196,13 @@ pub use self::erlang_nif_sys::{
     ErlNifPid,
     enif_clear_env,
     enif_free_env,
-    enif_self,
+    enif_get_local_pid,
+    enif_make_pid,
     enif_map_iterator_create,
+    enif_map_iterator_destroy,
     enif_map_iterator_get_pair,
     enif_map_iterator_next,
-    enif_map_iterator_destroy,
+    enif_self,
 };
 
 // Scheduling

--- a/src/wrapper/nif_interface.rs
+++ b/src/wrapper/nif_interface.rs
@@ -203,6 +203,10 @@ pub use self::erlang_nif_sys::{
     enif_map_iterator_get_pair,
     enif_map_iterator_next,
     enif_self,
+    ERL_NIF_THR_UNDEFINED,
+    ERL_NIF_THR_NORMAL_SCHEDULER,
+    ERL_NIF_THR_DIRTY_CPU_SCHEDULER,
+    ERL_NIF_THR_DIRTY_IO_SCHEDULER,
 };
 
 // Scheduling
@@ -225,6 +229,12 @@ pub unsafe fn enif_send(env: NIF_ENV,
                         msg_env: NIF_ENV,
                         msg: NIF_TERM) -> c_int {
     erlang_nif_sys::enif_send(env, to_pid, msg_env, msg)
+}
+
+pub fn enif_thread_type() -> c_int {
+    // Safe because this function isn't actually unsafe. It's marked unsafe
+    // because all C functions are marked unsafe by default.
+    unsafe { erlang_nif_sys::enif_thread_type() }
 }
 
 // Numbers

--- a/src/wrapper/pid.rs
+++ b/src/wrapper/pid.rs
@@ -1,0 +1,18 @@
+use super::nif_interface::{ self, NIF_ENV, NIF_TERM, ErlNifPid };
+use std::mem;
+
+pub unsafe fn get_local_pid(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifPid> {
+    let mut pid: ErlNifPid = mem::uninitialized();
+    if nif_interface::enif_get_local_pid(env, term, &mut pid) == 0 {
+        return None;
+    }
+    Some(pid)
+}
+
+// pub unsafe fn is_process_alive(env: NIF_ENV, pid: &ErlNifPid) -> bool {
+//     nif_interface::enif_is_process_alive(env, pid) != 0
+// }
+
+pub unsafe fn make_pid(env: NIF_ENV, pid: &ErlNifPid) -> NIF_TERM {
+    nif_interface::enif_make_pid(env, pid)
+}

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -33,5 +33,6 @@ defmodule RustlerTest do
   def threaded_fac(_), do: err()
   def threaded_sleep(_), do: err()
 
+  def send_all(_, _), do: err()
   def sublists(_), do: err()
 end

--- a/test/src/lib.in.rs
+++ b/test/src/lib.in.rs
@@ -35,6 +35,8 @@ rustler_export_nifs!(
 
         ("threaded_fac", 1, test_thread::threaded_fac),
         ("threaded_sleep", 1, test_thread::threaded_sleep),
+
+        ("send_all", 2, test_env::send_all),
         ("sublists", 1, test_env::sublists)
     ],
     Some(on_load)

--- a/test/src/test_env.rs
+++ b/test/src/test_env.rs
@@ -1,18 +1,45 @@
 use rustler::{NifEnv, NifTerm, NifResult, NifEncoder};
 use rustler::env::{OwnedEnv, SavedTerm};
-use rustler::types::list::NifListIterator;
 use rustler::types::atom;
+use rustler::types::list::NifListIterator;
+use rustler::types::pid::NifPid;
 use std::thread;
 
+// Send a message to several PIDs.
+pub fn send_all<'a>(env: NifEnv<'a>, args: &Vec<NifTerm<'a>>) -> NifResult<NifTerm<'a>> {
+    let pids: Vec<NifPid> = args[0].decode()?;
+    let message = args[1];
+
+    for pid in pids {
+        env.send(&pid, message);
+    }
+
+    Ok(message)
+}
+
 pub fn sublists<'a>(env: NifEnv<'a>, args: &Vec<NifTerm<'a>>) -> NifResult<NifTerm<'a>> {
+    // This is a "threaded NIF": it spawns a thread that sends a message back
+    // to the calling thread later.
     let pid = env.pid();
+
+    // Our worker thread will need an environment.  We can't ship `env` to the
+    // other thread, because the Erlang VM is going to tear it down as soon as
+    // we return from this NIF. So we use an `OwnedEnv`.
     let mut my_env = OwnedEnv::new();
+
+    // Start by taking the argument (which should be a list), and copying it
+    // into `my_env`, and reversing it. We can use `my_env.save()` to save
+    // terms in a form that doesn't have a lifetime parameter.
     let saved_reversed_list = my_env.run(|env| -> NifResult<SavedTerm> {
         let list_arg = args[0].in_env(env);
         Ok(my_env.save(list_arg.list_reverse()?))
     })?;
 
+    // Start the worker thread. This `move` closure takes ownership of both
+    // `my_env` and `saved_reversed_list`.
     thread::spawn(move || {
+        // Use `.send()` to get a `NifEnv` from our `OwnedEnv`,
+        // run some rust code, and finally send the result back to `pid`.
         my_env.send(&pid, |env| {
             let result: NifResult<NifTerm> = (|| {
                 let reversed_list = saved_reversed_list.load(env);

--- a/test/src/test_env.rs
+++ b/test/src/test_env.rs
@@ -13,7 +13,7 @@ pub fn sublists<'a>(env: NifEnv<'a>, args: &Vec<NifTerm<'a>>) -> NifResult<NifTe
     })?;
 
     thread::spawn(move || {
-        my_env.send(pid, |env| {
+        my_env.send(&pid, |env| {
             let result: NifResult<NifTerm> = (|| {
                 let reversed_list = saved_reversed_list.load(env);
                 let iter: NifListIterator = try!(reversed_list.decode());

--- a/test/src/test_env.rs
+++ b/test/src/test_env.rs
@@ -40,7 +40,7 @@ pub fn sublists<'a>(env: NifEnv<'a>, args: &Vec<NifTerm<'a>>) -> NifResult<NifTe
     thread::spawn(move || {
         // Use `.send()` to get a `NifEnv` from our `OwnedEnv`,
         // run some rust code, and finally send the result back to `pid`.
-        my_env.send(&pid, |env| {
+        my_env.send_and_clear(&pid, |env| {
             let result: NifResult<NifTerm> = (|| {
                 let reversed_list = saved_reversed_list.load(env);
                 let iter: NifListIterator = try!(reversed_list.decode());

--- a/test/test/env_test.exs
+++ b/test/test/env_test.exs
@@ -1,13 +1,44 @@
 defmodule RustlerTest.EnvTest do
   use ExUnit.Case, async: true
 
+  test "send" do
+    # Start 4 processes. Each one waits for one message,
+    # then sends a tuple back to this process.
+    parent = self()
+    child_pids = for _ <- 1..4 do
+      spawn(
+        fn ->
+          receive do
+            # Send the message itself, plus this process's pid.
+            msg -> send(parent, {self(), msg})
+          end
+        end)
+    end
+
+    # Send all 4 child processes a message.
+    RustlerTest.send_all(child_pids, {:hello, :world})
+
+    # Wait for all 4 processes to send something back.
+    results = for _ <- 1..4 do
+      receive do
+        # Collect the pids that the child processes send back.
+        {child_pid, {:hello, :world}} -> child_pid
+        _ -> raise :fail
+      end
+    end
+
+    # Each child should have sent back one result. (Sort before testing
+    # because results come back in arbitrary order.)
+    assert Enum.sort(results) == Enum.sort(child_pids)
+  end
+
   test "owned environments" do
     shop_menu = [
       {:spaniel, 34},
       {:ring_of_power, 75},
       {:rope, 4}
     ]
-    RustlerTest.sublists shop_menu
+    RustlerTest.sublists(shop_menu)
     receive do
       x ->
         assert x == [


### PR DESCRIPTION
The first commit adds our own `NifPid` wrapper type (like `NifTerm` and `NifEnv`) and stops exporting `ErlNifPid`.

The second commit adds an `env.send()` method.