### PR TITLE
Improve NIF loading with `use Rustler`

### DIFF
--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -3,12 +3,7 @@ defmodule NifNotLoadedError do
 end
 
 defmodule RustlerTest do
-  @on_load :load_nif
-
-  def load_nif do
-    require Rustler
-    Rustler.load_nif(:rustler_test, "rustler_test")
-  end
+  use Rustler, otp_app: :rustler_test
 
   defp err do
     throw NifNotLoadedError


### PR DESCRIPTION
This change improves NIF loading by implementing the `__using__` macro for the `Rustler` module.

Example:

```ex
defmodule Json do
  use Rustler, otp_app: :fast_json

  def encode(_), do: :erlang.nif_error(:nif_not_loaded)
  def decode(_), do: :erlang.nif_error(:nif_not_loaded)
end
```

I have added a module doc to show the various usage options.