### PR TITLE
reexport ErlNifTaskFlags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod term;
 
 pub use term::{ NifTerm };
 pub use types::{ NifEncoder, NifDecoder };
+pub use wrapper::nif_interface::ErlNifTaskFlags;
 pub mod resource;
 
 pub mod dynamic;


### PR DESCRIPTION
While making wrapper module private, the `ErlNifTaskFlags` was also shaded. This PR put it under the sun again.