### PR TITLE
implement NifEncoder for Option<T> and Result<T,E>

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -39,3 +39,21 @@ impl<'a, T> NifEncoder for &'a T where T: NifEncoder {
         <T as NifEncoder>::encode(self, env)
     }
 }
+
+impl<T> NifEncoder for Option<T> where T: NifEncoder {
+    fn encode<'c>(&self, env: NifEnv<'c>) -> NifTerm<'c> {
+        match *self {
+            Some(ref value) => value.encode(env),
+            None => atom::nil().encode(env),
+        }
+    }
+}
+
+impl<T, E> NifEncoder for Result<T, E> where T: NifEncoder, E: NifEncoder {
+    fn encode<'c>(&self, env: NifEnv<'c>) -> NifTerm<'c> {
+        match *self {
+            Ok(ref value) => (atom::ok().encode(env), value.encode(env)).encode(env),
+            Err(ref err) => (atom::error().encode(env), err.encode(env)).encode(env),
+        }
+    }
+}


### PR DESCRIPTION
Implementation for built-in types:

`Option::Some(value)` is_encoded as `value_encoded`
`Option::None` is encoded as `:nil`
`Result::Ok(value)` is encoded as `{:ok, value_encoded}`
`Result::Err(err)` is serialized as `{:error, err_encoded}`