### PR TITLE
Encode and decode Elixir structs

### DIFF
--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -1,0 +1,110 @@
+use ::syn::{self, Body, Field, MetaItem, Lit, Ident};
+use ::quote::{self, Tokens};
+
+pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &str> {
+    let elixir_module = {
+        let ref attr_value = ast.attrs.first().expect("NifStruct requires a 'module' attribute").value;
+        assert!(attr_value.name() == "module", "NifStruct requires a 'module' attribute");
+        match *attr_value {
+            MetaItem::NameValue(_, Lit::Str(ref value, _)) => format!("Elixir.{}", value),
+            _ => panic!("NifStruct requires a 'module' attribute"),
+        }
+    };
+
+    let struct_fields = match ast.body {
+        Body::Struct(ref data) => data.fields(),
+        Body::Enum(_) => panic!("NifStruct can only be used with structs"),
+    };
+
+    let num_lifetimes = ast.generics.lifetimes.len();
+    if num_lifetimes > 1 { panic!("Struct can only have one lifetime argument"); }
+    let has_lifetime = num_lifetimes == 1;
+
+    let field_atoms: Vec<Tokens> = struct_fields.iter().map(|field| {
+        let ident = field.clone().ident.unwrap();
+        let ident_str = ident.to_string();
+        let atom_fun = Ident::new(format!("atom_{}", ident_str));
+
+        quote! {
+            atom #atom_fun = #ident_str;
+        }
+    }).collect();
+    let atom_defs = quote! {
+        rustler_atoms! {
+            atom atom_struct = "__struct__";
+            atom atom_module = #elixir_module;
+            #(#field_atoms)*
+        }
+    };
+
+    let decoder = gen_decoder(&ast.ident, struct_fields, &atom_defs, has_lifetime);
+    let encoder = gen_encoder(&ast.ident, struct_fields, &atom_defs, has_lifetime);
+
+    Ok(quote! {
+        #decoder
+        #encoder
+    })
+}
+
+pub fn gen_decoder(struct_name: &Ident, fields: &[Field], atom_defs: &Tokens, has_lifetime: bool) -> Tokens {
+    let struct_type = if has_lifetime {
+        quote! { #struct_name <'a> }
+    } else {
+        quote! { #struct_name }
+    };
+
+    let field_defs: Vec<Tokens> = fields.iter().map(|field| {
+        let ident = field.clone().ident.unwrap();
+        let ident_str = ident.to_string();
+        let atom_fun = Ident::new(format!("atom_{}", ident_str));
+        quote! {
+            #ident: rustler::NifDecoder::decode(term.map_get(#atom_fun().encode(env))?)?
+        }
+    }).collect();
+
+    quote! {
+        impl<'a> rustler::NifDecoder<'a> for #struct_type {
+            fn decode(term: rustler::NifTerm<'a>) -> Result<Self, rustler::NifError> {
+                #atom_defs
+
+                let env = term.get_env();
+                let module: rustler::types::atom::NifAtom = term.map_get(atom_struct().to_term(env))?.decode()?;
+                if module != atom_module() {
+                    return Err(rustler::NifError::Atom("invalid_struct"));
+                }
+
+                Ok(#struct_name { #(#field_defs),* })
+            }
+        }
+    }
+}
+
+pub fn gen_encoder(struct_name: &Ident, fields: &[Field], atom_defs: &Tokens, has_lifetime: bool) -> Tokens {
+    let struct_type = if has_lifetime {
+        quote! { #struct_name <'b> }
+    } else {
+        quote! { #struct_name }
+    };
+
+    let field_defs: Vec<Tokens> = fields.iter().map(|field| {
+        let field_ident = field.clone().ident.unwrap();
+        let field_ident_str = field_ident.to_string();
+        let atom_fun = Ident::new(format!("atom_{}", field_ident_str));
+        quote! {
+            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).ok().unwrap();
+        }
+    }).collect();
+
+    quote! {
+        impl<'b> rustler::NifEncoder for #struct_type {
+            fn encode<'a>(&self, env: rustler::NifEnv<'a>) -> rustler::NifTerm<'a> {
+                #atom_defs
+
+                let mut map = rustler::types::map::map_new(env);
+                map = map.map_put(atom_struct().encode(env), atom_module().encode(env)).ok().unwrap();
+                #(#field_defs)*
+                map
+            }
+        }
+    }
+}

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "128"]
+
 extern crate proc_macro;
 use proc_macro::TokenStream;
 
@@ -9,6 +11,15 @@ extern crate quote;
 mod util;
 mod tuple;
 mod map;
+mod ex_struct;
+
+#[proc_macro_derive(NifStruct, attributes(module))]
+pub fn nif_struct(input: TokenStream) -> TokenStream {
+    let s = input.to_string();
+    let ast = syn::parse_macro_input(&s).unwrap();
+    let gen = ex_struct::transcoder_decorator(&ast);
+    gen.unwrap().parse().unwrap()
+}
 
 #[proc_macro_derive(NifMap)]
 pub fn nif_map(input: TokenStream) -> TokenStream {

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -47,4 +47,5 @@ defmodule RustlerTest do
 
   def tuple_echo(_), do: err()
   def map_echo(_), do: err()
+  def struct_echo(_), do: err()
 end

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -60,6 +60,7 @@ rustler_export_nifs!(
 
         ("tuple_echo", 1, test_codegen::tuple_echo),
         ("map_echo", 1, test_codegen::map_echo),
+        ("struct_echo", 1, test_codegen::struct_echo),
     ],
     Some(on_load)
 );

--- a/test/src/test_codegen.rs
+++ b/test/src/test_codegen.rs
@@ -22,3 +22,15 @@ pub fn map_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<
     let map: AddMap = try!(args[0].decode());
     Ok(map.encode(env))
 }
+
+#[derive(NifStruct)]
+#[module = "AddStruct"]
+struct AddStruct {
+    lhs: i32,
+    rhs: i32,
+}
+
+pub fn struct_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+    let add_struct: AddStruct = args[0].decode()?;
+    Ok(add_struct.encode(env))
+}

--- a/test/src/test_primitives.rs
+++ b/test/src/test_primitives.rs
@@ -1,4 +1,3 @@
-use rustler;
 use rustler::{NifEnv, NifTerm, NifEncoder, NifResult};
 
 pub fn add_u32<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {

--- a/test/test/codegen_test.exs
+++ b/test/test/codegen_test.exs
@@ -1,3 +1,7 @@
+defmodule AddStruct do
+  defstruct lhs: 0, rhs: 0
+end
+
 defmodule RustlerTest.CodegenTest do
   use ExUnit.Case, async: true
 
@@ -11,4 +15,9 @@ defmodule RustlerTest.CodegenTest do
     assert value == RustlerTest.map_echo(value)
   end
 
+  test "struct transcoder" do
+    value = %AddStruct{lhs: 45, rhs: 123}
+    assert value == RustlerTest.struct_echo(value)
+    assert :invalid_struct == RustlerTest.struct_echo(DateTime.utc_now())
+  end
 end


### PR DESCRIPTION
Implements #97: a procedural macro that generates `NifEncode` and `NifDecode` implementations to convert between a Rust struct and an Elixir struct. For example, given the following definition:

```rust
#[derive(NifStruct)]
#[module = "MyStruct"]
pub struct MyStruct {
    id: i32,
    name: String,
}
```

`MyStruct{id: 123, name: "Bob Jefferson".to_owned()}` encodes as 
`%MyStruct{id: 123, name: "Bob Jefferson"}`.