### PR TITLE
Replace Kernel.to_char_list with Kernel.to_charlist

### DIFF
--- a/rustler_mix/lib/rustler/toml_parser.ex
+++ b/rustler_mix/lib/rustler/toml_parser.ex
@@ -4,7 +4,7 @@ defmodule Rustler.TomlParser do
   # just used to extract version numbers from Cargo.toml files.
 
   def parse(text) do
-    {:ok, tokens, _test_chars} = text |> to_char_list |> :toml_lexer.string
+    {:ok, tokens, _test_chars} = text |> to_charlist |> :toml_lexer.string
     {:ok, parsed} = :toml_parser.parse(tokens)
 
     collect(parsed, [])


### PR DESCRIPTION
Fixes deprecation warning during build:

```
==> rustler
Compiling 2 files (.erl)
Compiling 6 files (.ex)
warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1
  lib/rustler/toml_parser.ex:7
```