### PR TITLE
encode and decode Unit + Untagged NewType Enums

### DIFF
--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -14,3 +14,4 @@ proc_macro = true
 [dependencies]
 syn = { version = "0.11.9", features = ["aster", "visit"] }
 quote = "0.3.15"
+heck = "0.3"

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -13,6 +13,7 @@ mod tuple;
 mod map;
 mod ex_struct;
 mod unit_enum;
+mod untagged_enum;
 
 #[proc_macro_derive(NifStruct, attributes(module))]
 pub fn nif_struct(input: TokenStream) -> TokenStream {
@@ -43,5 +44,13 @@ pub fn nif_unit_enum(input: TokenStream) -> TokenStream {
     let s = input.to_string();
     let ast = syn::parse_macro_input(&s).unwrap();
     let gen = unit_enum::transcoder_decorator(&ast);
+    gen.unwrap().parse().unwrap()
+}
+
+#[proc_macro_derive(NifUntaggedEnum)]
+pub fn nif_untagged_enum(input: TokenStream) -> TokenStream {
+    let s = input.to_string();
+    let ast = syn::parse_macro_input(&s).unwrap();
+    let gen = untagged_enum::transcoder_decorator(&ast);
     gen.unwrap().parse().unwrap()
 }

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
 
+extern crate heck;
 extern crate syn;
 
 #[macro_use]

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -12,6 +12,7 @@ mod util;
 mod tuple;
 mod map;
 mod ex_struct;
+mod unit_enum;
 
 #[proc_macro_derive(NifStruct, attributes(module))]
 pub fn nif_struct(input: TokenStream) -> TokenStream {
@@ -34,5 +35,13 @@ pub fn nif_tuple(input: TokenStream) -> TokenStream {
     let s = input.to_string();
     let ast = syn::parse_macro_input(&s).unwrap();
     let gen = tuple::transcoder_decorator(&ast);
+    gen.unwrap().parse().unwrap()
+}
+
+#[proc_macro_derive(NifUnitEnum)]
+pub fn nif_unit_enum(input: TokenStream) -> TokenStream {
+    let s = input.to_string();
+    let ast = syn::parse_macro_input(&s).unwrap();
+    let gen = unit_enum::transcoder_decorator(&ast);
     gen.unwrap().parse().unwrap()
 }

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -46,7 +46,7 @@ pub fn gen_decoder(struct_name: &Ident, fields: &Vec<Field>, atom_defs: &Tokens,
         let atom_fun = Ident::new(format!("atom_{}", ident_str));
 
         quote! {
-            #ident: rustler::NifDecoder::decode(term.map_get(#atom_fun().encode(env))?)?
+            #ident: ::rustler::NifDecoder::decode(term.map_get(#atom_fun().encode(env))?)?
         }
     }).collect();
 
@@ -57,8 +57,8 @@ pub fn gen_decoder(struct_name: &Ident, fields: &Vec<Field>, atom_defs: &Tokens,
     };
 
     quote! {
-        impl<'a> rustler::NifDecoder<'a> for #struct_type {
-            fn decode(term: rustler::NifTerm<'a>) -> Result<Self, rustler::NifError> {
+        impl<'a> ::rustler::NifDecoder<'a> for #struct_type {
+            fn decode(term: ::rustler::NifTerm<'a>) -> Result<Self, ::rustler::NifError> {
                 #atom_defs
 
                 let env = term.get_env();
@@ -87,11 +87,11 @@ pub fn gen_encoder(struct_name: &Ident, fields: &Vec<Field>, atom_defs: &Tokens,
     };
 
     quote! {
-        impl<'b> rustler::NifEncoder for #struct_type {
-            fn encode<'a>(&self, env: rustler::NifEnv<'a>) -> rustler::NifTerm<'a> {
+        impl<'b> ::rustler::NifEncoder for #struct_type {
+            fn encode<'a>(&self, env: ::rustler::NifEnv<'a>) -> ::rustler::NifTerm<'a> {
                 #atom_defs
 
-                let mut map = rustler::types::map::map_new(env);
+                let mut map = ::rustler::types::map::map_new(env);
                 #(#field_defs)*
                 map
             }

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -25,7 +25,7 @@ pub fn transcoder_decorator(ast: &syn::MacroInput) -> Result<quote::Tokens, &str
 pub fn gen_decoder(struct_name: &Ident, fields: &Vec<Field>, is_tuple: bool, has_lifetime: bool) -> Tokens {
     // Make a decoder for each of the fields in the struct.
     let field_defs: Vec<Tokens> = fields.iter().enumerate().map(|(idx, field)| {
-        let decoder = quote! { try!(rustler::NifDecoder::decode(terms[#idx])) };
+        let decoder = quote! { try!(::rustler::NifDecoder::decode(terms[#idx])) };
 
         if is_tuple {
             unimplemented!();
@@ -46,11 +46,11 @@ pub fn gen_decoder(struct_name: &Ident, fields: &Vec<Field>, is_tuple: bool, has
 
     // The implementation itself
     quote! {
-        impl<'a> rustler::NifDecoder<'a> for #struct_typ {
-            fn decode(term: rustler::NifTerm<'a>) -> Result<Self, rustler::NifError> {
-                let terms = try!(rustler::types::tuple::get_tuple(term));
+        impl<'a> ::rustler::NifDecoder<'a> for #struct_typ {
+            fn decode(term: ::rustler::NifTerm<'a>) -> Result<Self, ::rustler::NifError> {
+                let terms = try!(::rustler::types::tuple::get_tuple(term));
                 if terms.len() != #field_num {
-                    return Err(rustler::NifError::BadArg);
+                    return Err(::rustler::NifError::BadArg);
                 }
                 Ok(
                     #struct_name {
@@ -88,11 +88,11 @@ pub fn gen_encoder(struct_name: &Ident, fields: &Vec<Field>, is_tuple: bool, has
 
     // The implementation itself
     quote! {
-        impl<'b> rustler::NifEncoder for #struct_typ {
-            fn encode<'a>(&self, env: rustler::NifEnv<'a>) -> rustler::NifTerm<'a> {
-                use rustler::NifEncoder;
+        impl<'b> ::rustler::NifEncoder for #struct_typ {
+            fn encode<'a>(&self, env: ::rustler::NifEnv<'a>) -> ::rustler::NifTerm<'a> {
+                use ::rustler::NifEncoder;
                 let arr = #field_list_ast;
-                rustler::types::tuple::make_tuple(env, &arr)
+                ::rustler::types::tuple::make_tuple(env, &arr)
             }
         }
     }

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -1,0 +1,104 @@
+use std::ascii::AsciiExt;
+use ::syn::{self, Body, Ident, Variant, VariantData};
+use ::quote::{self, Tokens};
+
+pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &str> {
+    let variants = match ast.body {
+        Body::Enum(ref variants) => variants,
+        Body::Struct(_) => panic!("NifUnitEnum can only be used with enums"),
+    };
+
+    let num_lifetimes = ast.generics.lifetimes.len();
+    if num_lifetimes > 1 { panic!("Enum can only have one lifetime argument"); }
+    let has_lifetime = num_lifetimes == 1;
+
+    let atoms: Vec<Tokens> = variants.iter().map(|variant| {
+        if VariantData::Unit != variant.data {
+            panic!("NifUnitEnum can only be used with enums that contain all unit variants.");
+        }
+
+        let atom_str = variant.ident.to_string().to_ascii_lowercase();
+        let atom_fn  = Ident::new(format!("atom_{}", atom_str));
+        quote! {
+            atom #atom_fn = #atom_str;
+        }
+    }).collect();
+
+    let atom_defs = quote! {
+        rustler_atoms! {
+            #(#atoms)*
+        }
+    };
+
+    let decoder = gen_decoder(&ast.ident, variants, &atom_defs, has_lifetime);
+    let encoder = gen_encoder(&ast.ident, variants, &atom_defs, has_lifetime);
+
+    Ok(quote! {
+        #decoder
+        #encoder
+    })
+}
+
+pub fn gen_decoder(enum_name: &Ident, variants: &[Variant], atom_defs: &Tokens, has_lifetime: bool) -> Tokens {
+    let enum_type = if has_lifetime {
+        quote! { #enum_name <'b> }
+    } else {
+        quote! { #enum_name }
+    };
+
+    let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
+        let variant_ident = variant.ident.clone();
+        let atom_str      = variant_ident.to_string().to_ascii_lowercase();
+        let atom_fn       = Ident::new(format!("atom_{}", atom_str));
+
+        quote! {
+            if value == #atom_fn() {
+                return Ok ( #enum_name :: #variant_ident );
+            }
+        }
+    }).collect();
+
+    quote! {
+        impl<'a> ::rustler::NifDecoder<'a> for #enum_type {
+            fn decode(term: ::rustler::NifTerm<'a>) -> Result<Self, ::rustler::NifError> {
+                #atom_defs
+
+                let value = ::rustler::types::atom::NifAtom::from_term(term)?;
+
+                #(#variant_defs)*
+
+                Err(::rustler::NifError::Atom("invalid_variant"))
+            }
+        }
+    }
+}
+
+pub fn gen_encoder(enum_name: &Ident, variants: &[Variant], atom_defs: &Tokens, has_lifetime: bool) -> Tokens {
+    let enum_type = if has_lifetime {
+        quote! { #enum_name <'b> }
+    } else {
+        quote! { #enum_name }
+    };
+
+    let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
+        let variant_ident = variant.ident.clone();
+        let atom_str      = variant_ident.to_string().to_ascii_lowercase();
+        let atom_fn       = Ident::new(format!("atom_{}", atom_str));
+
+        quote! {
+            #enum_name :: #variant_ident => #atom_fn().encode(env),
+        }
+    }).collect();
+
+    quote! {
+        impl<'b> ::rustler::NifEncoder for #enum_type {
+            fn encode<'a>(&self, env: ::rustler::NifEnv<'a>) -> ::rustler::NifTerm<'a> {
+                #atom_defs
+
+                match *self {
+                    #(#variant_defs)*
+                }
+            }
+        }
+    }
+}

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -1,6 +1,6 @@
-use std::ascii::AsciiExt;
-use ::syn::{self, Body, Ident, Variant, VariantData};
-use ::quote::{self, Tokens};
+use heck::SnakeCase;
+use syn::{self, Body, Ident, Variant, VariantData};
+use quote::{self, Tokens};
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &str> {
     let variants = match ast.body {
@@ -19,7 +19,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &st
     }
 
     let atoms: Vec<Tokens> = variants.iter().map(|variant| {
-        let atom_str = variant.ident.to_string().to_ascii_lowercase();
+        let atom_str = variant.ident.to_string().to_snake_case();
         let atom_fn  = Ident::new(format!("atom_{}", atom_str));
         quote! {
             atom #atom_fn = #atom_str;
@@ -50,7 +50,7 @@ pub fn gen_decoder(enum_name: &Ident, variants: &[Variant], atom_defs: &Tokens, 
 
     let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
         let variant_ident = variant.ident.clone();
-        let atom_str      = variant_ident.to_string().to_ascii_lowercase();
+        let atom_str      = variant_ident.to_string().to_snake_case();
         let atom_fn       = Ident::new(format!("atom_{}", atom_str));
 
         quote! {
@@ -84,7 +84,7 @@ pub fn gen_encoder(enum_name: &Ident, variants: &[Variant], atom_defs: &Tokens, 
 
     let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
         let variant_ident = variant.ident.clone();
-        let atom_str      = variant_ident.to_string().to_ascii_lowercase();
+        let atom_str      = variant_ident.to_string().to_snake_case();
         let atom_fn       = Ident::new(format!("atom_{}", atom_str));
 
         quote! {

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -12,11 +12,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &st
     if num_lifetimes > 1 { panic!("Enum can only have one lifetime argument"); }
     let has_lifetime = num_lifetimes == 1;
 
-    let atoms: Vec<Tokens> = variants.iter().map(|variant| {
+    for variant in variants {
         if VariantData::Unit != variant.data {
             panic!("NifUnitEnum can only be used with enums that contain all unit variants.");
         }
+    }
 
+    let atoms: Vec<Tokens> = variants.iter().map(|variant| {
         let atom_str = variant.ident.to_string().to_ascii_lowercase();
         let atom_fn  = Ident::new(format!("atom_{}", atom_str));
         quote! {

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -1,0 +1,86 @@
+use ::syn::{self, Body, Ident, Variant, VariantData};
+use ::quote::{self, Tokens};
+
+pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &str> {
+    let variants = match ast.body {
+        Body::Enum(ref variants) => variants,
+        Body::Struct(_) => panic!("NifUntaggedEnum can only be used with enums"),
+    };
+
+    let num_lifetimes = ast.generics.lifetimes.len();
+    if num_lifetimes > 1 { panic!("Enum can only have one lifetime argument"); }
+    let has_lifetime = num_lifetimes == 1;
+
+    for variant in variants {
+        if let VariantData::Tuple(ref fields) = variant.data {
+            if fields.len() != 1 {
+                panic!("NifUntaggedEnum can only be used with enums that contain all NewType variants.");
+            }
+        } else {
+            panic!("NifUntaggedEnum can only be used with enums that contain all NewType variants.");
+        }
+    }
+
+    let decoder = gen_decoder(&ast.ident, variants, has_lifetime);
+    let encoder = gen_encoder(&ast.ident, variants, has_lifetime);
+
+    Ok(quote! {
+        #decoder
+        #encoder
+    })
+}
+
+pub fn gen_decoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) -> Tokens {
+    let enum_type = if has_lifetime {
+        quote! { #enum_name <'b> }
+    } else {
+        quote! { #enum_name }
+    };
+
+    let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
+        let variant_name = variant.ident.clone();
+        let field_type   = variant.data.fields()[0].ty.clone();
+
+        quote! {
+            if let Ok(inner) = #field_type::decode(term) {
+                return Ok( #enum_name :: #variant_name ( inner ) )
+            }
+        }
+    }).collect();
+
+    quote! {
+        impl<'a> ::rustler::NifDecoder<'a> for #enum_type {
+            fn decode(term: ::rustler::NifTerm<'a>) -> Result<Self, ::rustler::NifError> {
+                #(#variant_defs)*
+
+                Err(::rustler::NifError::Atom("invalid_variant"))
+            }
+        }
+    }
+}
+
+pub fn gen_encoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) -> Tokens {
+    let enum_type = if has_lifetime {
+        quote! { #enum_name <'b> }
+    } else {
+        quote! { #enum_name }
+    };
+
+    let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
+        let variant_name = variant.ident.clone();
+
+        quote! {
+            #enum_name :: #variant_name ( ref inner ) => inner.encode(env),
+        }
+    }).collect();
+
+    quote! {
+        impl<'b> ::rustler::NifEncoder for #enum_type {
+            fn encode<'a>(&self, env: ::rustler::NifEnv<'a>) -> ::rustler::NifTerm<'a> {
+                match *self {
+                    #(#variant_defs)*
+                }
+            }
+        }
+    }
+}

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -51,6 +51,7 @@ defmodule RustlerTest do
   def map_echo(_), do: err()
   def struct_echo(_), do: err()
   def unit_enum_echo(_), do: err()
+  def untagged_enum_echo(_), do: err()
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -50,6 +50,7 @@ defmodule RustlerTest do
   def tuple_echo(_), do: err()
   def map_echo(_), do: err()
   def struct_echo(_), do: err()
+  def unit_enum_echo(_), do: err()
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -65,6 +65,7 @@ rustler_export_nifs!(
         ("tuple_echo", 1, test_codegen::tuple_echo),
         ("map_echo", 1, test_codegen::map_echo),
         ("struct_echo", 1, test_codegen::struct_echo),
+        ("unit_enum_echo", 1, test_codegen::unit_enum_echo),
 
         ("dirty_cpu", 0, test_dirty::dirty_cpu, NifScheduleFlags::DirtyCpu),
         ("dirty_io", 0, test_dirty::dirty_io, NifScheduleFlags::DirtyIo),

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -66,6 +66,7 @@ rustler_export_nifs!(
         ("map_echo", 1, test_codegen::map_echo),
         ("struct_echo", 1, test_codegen::struct_echo),
         ("unit_enum_echo", 1, test_codegen::unit_enum_echo),
+        ("untagged_enum_echo", 1, test_codegen::untagged_enum_echo),
 
         ("dirty_cpu", 0, test_dirty::dirty_cpu, NifScheduleFlags::DirtyCpu),
         ("dirty_io", 0, test_dirty::dirty_io, NifScheduleFlags::DirtyIo),

--- a/test/src/test_codegen.rs
+++ b/test/src/test_codegen.rs
@@ -34,3 +34,15 @@ pub fn struct_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTe
     let add_struct: AddStruct = args[0].decode()?;
     Ok(add_struct.encode(env))
 }
+
+#[derive(NifUnitEnum)]
+enum UnitEnum {
+    Foo,
+    Bar,
+    Baz,
+}
+
+pub fn unit_enum_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+    let unit_enum: UnitEnum = args[0].decode()?;
+    Ok(unit_enum.encode(env))
+}

--- a/test/src/test_codegen.rs
+++ b/test/src/test_codegen.rs
@@ -1,4 +1,3 @@
-use rustler;
 use rustler::{NifEnv, NifTerm, NifEncoder, NifResult};
 
 #[derive(NifTuple)]
@@ -8,7 +7,7 @@ struct AddTuple {
 }
 
 pub fn tuple_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
-    let tuple: AddTuple = try!(args[0].decode());
+    let tuple: AddTuple = args[0].decode()?;
     Ok(tuple.encode(env))
 }
 
@@ -37,8 +36,7 @@ pub fn struct_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTe
 
 #[derive(NifUnitEnum)]
 enum UnitEnum {
-    Foo,
-    Bar,
+    FooBar,
     Baz,
 }
 

--- a/test/src/test_codegen.rs
+++ b/test/src/test_codegen.rs
@@ -46,3 +46,15 @@ pub fn unit_enum_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<Ni
     let unit_enum: UnitEnum = args[0].decode()?;
     Ok(unit_enum.encode(env))
 }
+
+#[derive(NifUntaggedEnum)]
+enum UntaggedEnum {
+    Foo(u32),
+    Bar(String),
+    Baz(AddStruct),
+}
+
+pub fn untagged_enum_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+    let untagged_enum: UntaggedEnum = args[0].decode()?;
+    Ok(untagged_enum.encode(env))
+}

--- a/test/src/test_dirty.rs
+++ b/test/src/test_dirty.rs
@@ -1,7 +1,7 @@
 use rustler::NifEncoder;
 use rustler::{NifEnv, NifTerm, NifResult};
 
-use std::{ thread, time };
+use std::time;
 
 mod atoms {
     rustler_atoms! {
@@ -11,14 +11,14 @@ mod atoms {
 
 // TODO: Make these realistic
 
-pub fn dirty_cpu<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+pub fn dirty_cpu<'a>(env: NifEnv<'a>, _: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
     let duration = time::Duration::from_millis(100);
     ::std::thread::sleep(duration);
 
     Ok(atoms::ok().encode(env))
 }
 
-pub fn dirty_io<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+pub fn dirty_io<'a>(env: NifEnv<'a>, _: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
     let duration = time::Duration::from_millis(100);
     ::std::thread::sleep(duration);
 

--- a/test/test/codegen_test.exs
+++ b/test/test/codegen_test.exs
@@ -27,4 +27,11 @@ defmodule RustlerTest.CodegenTest do
     assert :baz == RustlerTest.unit_enum_echo(:baz)
     assert :invalid_variant == RustlerTest.unit_enum_echo(:somethingelse)
   end
+
+  test "untagged enum transcoder" do
+    assert 123 == RustlerTest.untagged_enum_echo(123)
+    assert "Hello" == RustlerTest.untagged_enum_echo("Hello")
+    assert %AddStruct{lhs: 45, rhs: 123} = RustlerTest.untagged_enum_echo(%AddStruct{lhs: 45, rhs: 123})
+    assert :invalid_variant == RustlerTest.untagged_enum_echo([1,2,3,4])
+  end
 end

--- a/test/test/codegen_test.exs
+++ b/test/test/codegen_test.exs
@@ -22,8 +22,7 @@ defmodule RustlerTest.CodegenTest do
   end
 
   test "unit enum transcoder" do
-    assert :foo == RustlerTest.unit_enum_echo(:foo)
-    assert :bar == RustlerTest.unit_enum_echo(:bar)
+    assert :foo_bar == RustlerTest.unit_enum_echo(:foo_bar)
     assert :baz == RustlerTest.unit_enum_echo(:baz)
     assert :invalid_variant == RustlerTest.unit_enum_echo(:somethingelse)
   end

--- a/test/test/codegen_test.exs
+++ b/test/test/codegen_test.exs
@@ -20,4 +20,11 @@ defmodule RustlerTest.CodegenTest do
     assert value == RustlerTest.struct_echo(value)
     assert :invalid_struct == RustlerTest.struct_echo(DateTime.utc_now())
   end
+
+  test "unit enum transcoder" do
+    assert :foo == RustlerTest.unit_enum_echo(:foo)
+    assert :bar == RustlerTest.unit_enum_echo(:bar)
+    assert :baz == RustlerTest.unit_enum_echo(:baz)
+    assert :invalid_variant == RustlerTest.unit_enum_echo(:somethingelse)
+  end
 end


### PR DESCRIPTION
Implements two new procedural macros, `NifUnitEnum` and `NifUntaggedEnum`, to generate conversion code between Rust Unit / Untagged NewType enums and Elixir values.

**Example**

Given the following Rust code:

```rust
#[derive(NifUnitEnum)]
enum Enum1 {
    FooBar,
    Baz,
}

#[derive(NifUntaggedEnum)]
enum Enum2 {
    A(u32),
    B(String),
    C(Enum1),
}
```

`Enum1::FooBar` is encoded as `:foo_bar`
`Enum1::Baz` is encoded as `:baz`.
`Enum2::A(123)` is encoded as `123`
`Enum2::B("Hello".into())` is encoded as `"Hello"`
`Enum2::C(Enum1::Foobar)` is encoded as `:foo_bar`