### PR TITLE
Encode and decode records (tagged tuples)

### DIFF
--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -11,6 +11,7 @@ extern crate quote;
 
 mod util;
 mod tuple;
+mod record;
 mod map;
 mod ex_struct;
 mod unit_enum;
@@ -37,6 +38,14 @@ pub fn nif_tuple(input: TokenStream) -> TokenStream {
     let s = input.to_string();
     let ast = syn::parse_macro_input(&s).unwrap();
     let gen = tuple::transcoder_decorator(&ast);
+    gen.unwrap().parse().unwrap()
+}
+
+#[proc_macro_derive(NifRecord, attributes(tag))]
+pub fn nif_record(input: TokenStream) -> TokenStream {
+    let s = input.to_string();
+    let ast = syn::parse_macro_input(&s).unwrap();
+    let gen = record::transcoder_decorator(&ast);
     gen.unwrap().parse().unwrap()
 }
 

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -1,0 +1,119 @@
+use ::syn::{self, Field, VariantData, MetaItem, Lit, Ident};
+use ::quote::{self, Tokens};
+
+pub fn transcoder_decorator(ast: &syn::MacroInput) -> Result<quote::Tokens, &str> {
+    let record_tag = {
+        let ref attr_value = ast.attrs.first().expect("NifRecord requires a 'tag' attribute").value;
+        assert!(attr_value.name() == "tag", "NifRecord requires a 'tag' attribute");
+        match *attr_value {
+            MetaItem::NameValue(_, Lit::Str(ref value, _)) => value,
+            _ => panic!("NifRecord requires a 'tag' attribute"),
+        }
+    };
+
+    let struct_fields = match ast.body {
+        syn::Body::Struct(VariantData::Struct(ref data)) => data,
+        _ => return Err("Must decorate a struct"),
+    };
+
+    let num_lifetimes = ast.generics.lifetimes.len();
+    if num_lifetimes > 1 {
+        return Err("Struct can only have one lifetime argument");
+    }
+    let has_lifetime = num_lifetimes == 1;
+
+    let atom_defs = quote! {
+        rustler_atoms! {
+            atom atom_tag = #record_tag;
+        }
+    };
+
+    let decoder = gen_decoder(&ast.ident, struct_fields, &atom_defs, has_lifetime);
+    let encoder = gen_encoder(&ast.ident, struct_fields, &atom_defs, has_lifetime);
+
+    Ok(quote! {
+        #decoder
+        #encoder
+    })
+}
+
+pub fn gen_decoder(struct_name: &Ident, fields: &Vec<Field>, atom_defs: &Tokens, has_lifetime: bool) -> Tokens {
+    // Make a decoder for each of the fields in the struct.
+    let field_defs: Vec<Tokens> = fields.iter().enumerate().map(|(idx, field)| {
+        let decoder = quote! { try!(::rustler::NifDecoder::decode(terms[#idx + 1])) };
+
+        let ident = field.clone().ident.unwrap();
+        quote! { #ident: #decoder }
+    }).collect();
+
+    // If the struct has a lifetime argument, put that in the struct type.
+    let struct_typ = if has_lifetime {
+        quote! { #struct_name <'a> }
+    } else {
+        quote! { #struct_name }
+    };
+
+    let field_num = field_defs.len();
+
+    // The implementation itself
+    quote! {
+        impl<'a> ::rustler::NifDecoder<'a> for #struct_typ {
+            fn decode(term: ::rustler::NifTerm<'a>) -> Result<Self, ::rustler::NifError> {
+                let terms = try!(::rustler::types::tuple::get_tuple(term));
+                if terms.len() != #field_num + 1 {
+                    return Err(::rustler::NifError::Atom("invalid_record"));
+                }
+
+                #atom_defs
+
+                let tag : ::rustler::types::atom::NifAtom  = terms[0].decode()?;
+                if tag != atom_tag() {
+                    return Err(::rustler::NifError::Atom("invalid_record"));
+                }
+
+                Ok(
+                    #struct_name {
+                        #(#field_defs),*
+                    }
+                )
+            }
+        }
+    }
+}
+
+pub fn gen_encoder(struct_name: &Ident, fields: &Vec<Field>, atom_defs: &Tokens, has_lifetime: bool) -> Tokens {
+    // Make a field encoder expression for each of the items in the struct.
+    let field_encoders: Vec<Tokens> = fields.iter().map(|field| {
+        let field_ident = field.clone().ident.unwrap();
+        let field_source = quote! { self.#field_ident };
+        quote! { #field_source.encode(env) }
+    }).collect();
+
+    let tag_encoder = quote! { atom_tag().encode(env) };
+
+    // Build a slice ast from the field_encoders
+
+    let field_list_ast = quote! {
+        [#tag_encoder, #(#field_encoders),*]
+    };
+
+    // If the struct has a lifetime argument, put that in the struct type.
+    let struct_typ = if has_lifetime {
+        quote! { #struct_name <'b> }
+    } else {
+        quote! { #struct_name }
+    };
+
+    // The implementation itself
+    quote! {
+        impl<'b> ::rustler::NifEncoder for #struct_typ {
+            fn encode<'a>(&self, env: ::rustler::NifEnv<'a>) -> ::rustler::NifTerm<'a> {
+                #atom_defs
+
+                use ::rustler::NifEncoder;
+                let arr = #field_list_ast;
+                ::rustler::types::tuple::make_tuple(env, &arr)
+            }
+        }
+    }
+}

--- a/test/lib/rustler_test.ex
+++ b/test/lib/rustler_test.ex
@@ -48,6 +48,7 @@ defmodule RustlerTest do
   def sublists(_), do: err()
 
   def tuple_echo(_), do: err()
+  def record_echo(_), do: err()
   def map_echo(_), do: err()
   def struct_echo(_), do: err()
   def unit_enum_echo(_), do: err()

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -63,6 +63,7 @@ rustler_export_nifs!(
         ("sublists", 1, test_env::sublists),
 
         ("tuple_echo", 1, test_codegen::tuple_echo),
+        ("record_echo", 1, test_codegen::record_echo),
         ("map_echo", 1, test_codegen::map_echo),
         ("struct_echo", 1, test_codegen::struct_echo),
         ("unit_enum_echo", 1, test_codegen::unit_enum_echo),

--- a/test/src/test_codegen.rs
+++ b/test/src/test_codegen.rs
@@ -11,6 +11,18 @@ pub fn tuple_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTer
     Ok(tuple.encode(env))
 }
 
+#[derive(NifRecord)]
+#[tag = "record"]
+struct AddRecord {
+    lhs: i32,
+    rhs: i32,
+}
+
+pub fn record_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+    let record: AddRecord = args[0].decode()?;
+    Ok(record.encode(env))
+}
+
 #[derive(NifMap)]
 struct AddMap {
     lhs: i32,

--- a/test/test/codegen_test.exs
+++ b/test/test/codegen_test.exs
@@ -2,6 +2,11 @@ defmodule AddStruct do
   defstruct lhs: 0, rhs: 0
 end
 
+defmodule AddRecord do
+  import Record
+  defrecord :record, [lhs: 1, rhs: 2]
+end
+
 defmodule RustlerTest.CodegenTest do
   use ExUnit.Case, async: true
 
@@ -19,6 +24,15 @@ defmodule RustlerTest.CodegenTest do
     value = %AddStruct{lhs: 45, rhs: 123}
     assert value == RustlerTest.struct_echo(value)
     assert :invalid_struct == RustlerTest.struct_echo(DateTime.utc_now())
+  end
+
+  test "record transcoder" do
+    import AddRecord
+    value = record()
+    assert value == RustlerTest.record_echo(value)
+    assert :invalid_record == RustlerTest.record_echo({})
+    assert :invalid_record == RustlerTest.record_echo({:wrong_tag, 1, 2})
+    assert_raise ArgumentError, fn -> RustlerTest.record_echo(:somethingelse) end
   end
 
   test "unit enum transcoder" do


### PR DESCRIPTION
This changeset adds functionality to derive a Rust struct from an Erlang [record](http://erlang.org/doc/reference_manual/records.html), which could also be generated by a [macro](https://hexdocs.pm/elixir/Record.html) in Elixir. Its advantage over decoding an Elixir struct is reduced runtime overhead, as no maps are involved and tuple elements can be accessed in constant time. Its advantage over decoding directly from a tuple is that it performs a simple check to verify that the record's tag matches the one described with the `tag` attribute of the rust struct. The code merges pre-existing functionality from `NifStruct` and `NifTuple`.

Consider this example taken from the test case. We can define a record using Elixir:

```elixir
defmodule AddRecord do
  import Record
  defrecord :record, [lhs: 1, rhs: 2]
end
```

With this changeset, this record can be represented with rustler:

```rust
#[derive(NifRecord)]
#[tag = "record"]
struct AddRecord {
    lhs: i32,
    rhs: i32,
}

pub fn record_echo<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
    let record: AddRecord = args[0].decode()?;
    Ok(record.encode(env))
}
```