### PR TITLE
Fix argument type to load_nif

### DIFF
--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -74,7 +74,7 @@ defmodule Rustler do
 
     priv_dir = otp_app |> :code.priv_dir() |> to_string()
     load_data = opts[:load_data] || config[:load_data] || 0
-    so_path = "#{priv_dir}/native/#{crate}"
+    so_path = String.to_charlist("#{priv_dir}/native/#{crate}")
 
     {so_path, load_data}
   end


### PR DESCRIPTION
Erlang's erlang:load_nif/2 function expects a string() as its first argument. Although the function accepts  binary string as well, dialyzer complains due to a broken contract:

    The call erlang:load_nif(_@1::<<_:64,_:_*8>>,_@2::any()) breaks the
    contract (Path,LoadInfo) -> 'ok' | Error when Path :: string(), LoadInfo
    :: term(), Error :: {'error',{Reason,Text::string()}}, Reason ::
    'load_failed' | 'bad_lib' | 'load' | 'reload' | 'upgrade' | 'old_code'

Note that the spec of `erlang:load_nif/2` is likely underspecified in Erlang itself and should probably be reported.