### PR TITLE
Use :erlang.nif_error/1 in README

### DIFF
--- a/rustler_mix/priv/templates/basic/README.md
+++ b/rustler_mix/priv/templates/basic/README.md
@@ -13,7 +13,7 @@ defmodule <%= module %> do
     use Rustler, otp_app: [otp app], crate: "<%= library_name %>"
 
     # When your NIF is loaded, it will override this function.
-    def add(_a, _b), do: throw :nif_not_loaded
+    def add(_a, _b), do: :erlang.nif_error(:nif_not_loaded)
 end
 ```
 


### PR DESCRIPTION
By using :erlang.nif_error/1, false warnings from Dialyzer are suppressed. This should help
users new to Rustler to avoid useless warnings.