### PR TITLE
Fix attribute order for NifRecord

### DIFF
--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -3,7 +3,9 @@ use ::quote::{self, Tokens};
 
 pub fn transcoder_decorator(ast: &syn::MacroInput) -> Result<quote::Tokens, &str> {
     let record_tag = {
-        let ref attr_value = ast.attrs.first().expect("NifRecord requires a 'tag' attribute").value;
+        let ref attr_value = ast.attrs.iter()
+            .find(|attr| attr.name() == "tag")
+            .expect("NifRecord requires a 'tag' attribute").value;
         assert!(attr_value.name() == "tag", "NifRecord requires a 'tag' attribute");
         match *attr_value {
             MetaItem::NameValue(_, Lit::Str(ref value, _)) => value,

--- a/rustler_tests/src/test_codegen.rs
+++ b/rustler_tests/src/test_codegen.rs
@@ -1,4 +1,4 @@
-use rustler::{Env, Term, Encoder, NifResult};
+use rustler::{Encoder, Env, NifResult, Term};
 
 #[derive(NifTuple)]
 struct AddTuple {
@@ -12,6 +12,7 @@ pub fn tuple_echo<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
 }
 
 #[derive(NifRecord)]
+#[must_use] // Added to check attribute order (see similar issue #152)
 #[tag = "record"]
 struct AddRecord {
     lhs: i32,


### PR DESCRIPTION
This is a follow-up to PR #153 and re-uses the fix by @kraythen.