### PR TITLE
add Atom::try_from_bytes

### DIFF
--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -43,6 +43,22 @@ impl Atom {
         unsafe { Ok(Atom::from_nif_term(atom::make_atom(env.as_c_arg(), bytes))) }
     }
 
+    /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_existing_atom/2`, if atom with given text representation exists.
+    ///
+    /// # Errors
+    /// `Error::BadArg` if `bytes.len() > 255`.
+    pub fn try_from_bytes<'a>(env: Env<'a>, bytes: &[u8]) -> NifResult<Option<Atom>> {
+        if bytes.len() > 255 {
+            return Err(Error::BadArg);
+        }
+        unsafe {
+            match atom::make_existing_atom(env.as_c_arg(), bytes) {
+                Some(term) => Ok(Some(Atom::from_nif_term(term))),
+                None => return Ok(None),
+            }
+        }
+    }
+
     /// Return the atom whose text representation is the given `string`, like `erlang:list_to_atom/2`.
     ///
     /// # Errors

--- a/rustler/src/wrapper/atom.rs
+++ b/rustler/src/wrapper/atom.rs
@@ -6,6 +6,20 @@ pub unsafe fn make_atom(env: NIF_ENV, name: &[u8]) -> NIF_TERM {
     nif_interface::enif_make_atom_len(env, name.as_ptr(), name.len())
 }
 
+pub unsafe fn make_existing_atom(env: NIF_ENV, name: &[u8]) -> Option<NIF_TERM> {
+    let mut atom_out: NIF_TERM = 0;
+    let success = nif_interface::enif_make_existing_atom_len(
+        env,
+        name.as_ptr(),
+        name.len(),
+        &mut atom_out as *mut NIF_TERM,
+    );
+    if success == 0 {
+        return None;
+    }
+    Some(atom_out)
+}
+
 /// Get the contents of this atom as a string.
 ///
 /// If you only need to test for equality, comparing the terms directly

--- a/rustler/src/wrapper/nif_interface.rs
+++ b/rustler/src/wrapper/nif_interface.rs
@@ -130,6 +130,21 @@ pub unsafe fn enif_is_tuple(env: NIF_ENV, term: NIF_TERM) -> c_int {
 pub unsafe fn enif_make_atom_len(env: NIF_ENV, string: *const u8, length: size_t) -> NIF_TERM {
     erlang_nif_sys::enif_make_atom_len(env, string, length)
 }
+pub unsafe fn enif_make_existing_atom_len(
+    env: NIF_ENV,
+    string: *const u8,
+    length: size_t,
+    atom_out: *mut NIF_TERM,
+) -> c_int {
+    erlang_nif_sys::enif_make_existing_atom_len(
+        env,
+        string,
+        length,
+        atom_out,
+        erlang_nif_sys::ErlNifCharEncoding::ERL_NIF_LATIN1,
+    )
+}
+
 pub unsafe fn enif_get_atom_latin1(
     env: NIF_ENV,
     term: NIF_TERM,

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -41,6 +41,8 @@ defmodule RustlerTest do
 
   def atom_to_string(_), do: err()
   def atom_equals_ok(_), do: err()
+  def binary_to_atom(_), do: err()
+  def binary_to_existing_atom(_), do: err()
 
   def threaded_fac(_), do: err()
   def threaded_sleep(_), do: err()

--- a/rustler_tests/src/lib.rs
+++ b/rustler_tests/src/lib.rs
@@ -48,6 +48,8 @@ rustler_export_nifs!(
 
         ("atom_to_string", 1, test_atom::atom_to_string),
         ("atom_equals_ok", 1, test_atom::atom_equals_ok),
+        ("binary_to_atom", 1, test_atom::binary_to_atom),
+        ("binary_to_existing_atom", 1, test_atom::binary_to_existing_atom),
 
         ("make_shorter_subbinary", 1, test_binary::make_shorter_subbinary),
         ("parse_integer", 1, test_binary::parse_integer),

--- a/rustler_tests/src/test_atom.rs
+++ b/rustler_tests/src/test_atom.rs
@@ -1,5 +1,6 @@
+use rustler::types::{atom::Atom, binary::Binary};
 use rustler::Encoder;
-use rustler::{Env, Term, NifResult};
+use rustler::{Env, NifResult, Term};
 
 mod atoms {
     rustler_atoms! {
@@ -7,8 +8,7 @@ mod atoms {
     }
 }
 
-pub fn on_load(_env: Env) {
-}
+pub fn on_load(_env: Env) {}
 
 pub fn atom_to_string<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     let atom_string = try!(args[0].atom_to_string());
@@ -17,4 +17,16 @@ pub fn atom_to_string<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>
 
 pub fn atom_equals_ok<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     Ok((atoms::ok() == args[0]).encode(env))
+}
+
+pub fn binary_to_atom<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+    let binary: Binary = args[0].decode()?;
+    let atom = Atom::from_bytes(env, binary.as_slice())?;
+    Ok(atom.encode(env))
+}
+
+pub fn binary_to_existing_atom<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+    let binary: Binary = args[0].decode()?;
+    let atom = Atom::try_from_bytes(env, binary.as_slice())?;
+    Ok(atom.encode(env))
 }

--- a/rustler_tests/test/atom_test.exs
+++ b/rustler_tests/test/atom_test.exs
@@ -7,6 +7,16 @@ defmodule RustlerTest.AtomTest do
     assert RustlerTest.atom_to_string(:erlang.list_to_atom([197])) == "Å"
   end
 
+  test "binary to atom" do
+    assert RustlerTest.binary_to_atom("test_atom") == :test_atom
+  end
+
+  test "binary to existing atom" do
+    assert RustlerTest.binary_to_existing_atom("test_atom_nonexisting") == nil
+    RustlerTest.binary_to_atom("test_atom_nonexisting")
+    assert RustlerTest.binary_to_existing_atom("test_atom_nonexisting") != nil
+  end
+
   test "atom to string for non-atom should raise" do
     assert catch_error(RustlerTest.atom_to_string("already a string")) == :badarg
   end


### PR DESCRIPTION
- add `Atom::try_from_bytes` which maps to `binary_to_existing_atom/2`
- test testcases for `Atom::{from_bytes,try_from_bytes}`