### PR TITLE
Configure link args with cargo config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Fixes #151 

```
λ cargo build
   Compiling void v1.0.2
   Compiling unicode-xid v0.0.4                                                                                                                               
   Compiling erlang_nif-sys v0.6.4                                                                                                                            
   Compiling quote v0.3.15                                                                                                                                    
   Compiling unicode-segmentation v1.2.1                                                                                                                      
   Compiling lazy_static v1.0.1                                                                                                                               
   Compiling unreachable v0.1.1                                                                                                                               
   Compiling synom v0.11.3                                                                                                                                    
   Compiling heck v0.3.0                                                                                                                                      
   Compiling syn v0.11.11                                                                                                                                     
   Compiling rustler v0.18.1-alpha.0 (/Users/scrogson/github/hansihe/rustler/rustler)                                                                         
   Compiling rustler_codegen v0.18.0 (/Users/scrogson/github/hansihe/rustler/rustler_codegen)                                                                 
   Compiling rustler_test v0.1.0 (/Users/scrogson/github/hansihe/rustler/rustler_tests)                                                                       
    Finished dev [unoptimized + debuginfo] target(s) in 17.32s
```