### PR TITLE
Bump quote and syn using proc_macro2

### DIFF
--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -15,3 +15,4 @@ proc_macro = true
 syn = { version = "0.15.24", features = ["derive"] }
 quote = "0.6.10"
 heck = "0.3"
+proc-macro2 = "0.4"

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -13,5 +13,5 @@ proc_macro = true
 
 [dependencies]
 syn = { version = "0.11.9", features = ["aster", "visit"] }
-quote = "0.3.15"
+quote = "0.6.10"
 heck = "0.3"

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -12,6 +12,6 @@ name = "rustler_codegen"
 proc_macro = true
 
 [dependencies]
-syn = { version = "0.11.9", features = ["aster", "visit"] }
+syn = { version = "0.15.24", features = ["derive"] }
 quote = "0.6.10"
 heck = "0.3"

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -5,6 +5,7 @@ use proc_macro::TokenStream;
 
 extern crate heck;
 extern crate syn;
+extern crate proc_macro2;
 
 #[macro_use]
 extern crate quote;
@@ -39,10 +40,8 @@ mod untagged_enum;
 /// ```
 #[proc_macro_derive(NifStruct, attributes(module))]
 pub fn nif_struct(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_macro_input(&s).unwrap();
-    let gen = ex_struct::transcoder_decorator(&ast);
-    gen.unwrap().parse().unwrap()
+    let ast = syn::parse(input).unwrap();
+    ex_struct::transcoder_decorator(&ast).into()
 }
 
 /// Implementation of a macro that lets the user annotate a struct with `NifMap` so that the
@@ -65,10 +64,8 @@ pub fn nif_struct(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_derive(NifMap)]
 pub fn nif_map(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_macro_input(&s).unwrap();
-    let gen = map::transcoder_decorator(&ast);
-    gen.unwrap().parse().unwrap()
+    let ast = syn::parse(input).unwrap();
+    map::transcoder_decorator(&ast).into()
 }
 
 /// Implementation of a macro that lets the user annotate a struct with `NifTuple` so that the
@@ -93,10 +90,8 @@ pub fn nif_map(input: TokenStream) -> TokenStream {
 /// The size of the tuple will depend on the number of elements in the struct.
 #[proc_macro_derive(NifTuple)]
 pub fn nif_tuple(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_macro_input(&s).unwrap();
-    let gen = tuple::transcoder_decorator(&ast);
-    gen.unwrap().parse().unwrap()
+    let ast = syn::parse(input).unwrap();
+    tuple::transcoder_decorator(&ast).into()
 }
 
 /// Implementation of the `NifRecord` macro that lets the user annotate a struct that will
@@ -122,10 +117,8 @@ pub fn nif_tuple(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_derive(NifRecord, attributes(tag))]
 pub fn nif_record(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_macro_input(&s).unwrap();
-    let gen = record::transcoder_decorator(&ast);
-    gen.unwrap().parse().unwrap()
+    let ast = syn::parse(input).unwrap();
+    record::transcoder_decorator(&ast).into()
 }
 
 /// Implementation of the `NifUnitEnum` macro that lets the user annotate an enum with a unit type
@@ -153,10 +146,8 @@ pub fn nif_record(input: TokenStream) -> TokenStream {
 /// that isn't in the Rust enum.
 #[proc_macro_derive(NifUnitEnum)]
 pub fn nif_unit_enum(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_macro_input(&s).unwrap();
-    let gen = unit_enum::transcoder_decorator(&ast);
-    gen.unwrap().parse().unwrap()
+    let ast = syn::parse(input).unwrap();
+    unit_enum::transcoder_decorator(&ast).into()
 }
 
 /// Implementation of the `NifUntaggedEnum` macro that lets the user annotate an enum that will
@@ -192,8 +183,6 @@ pub fn nif_unit_enum(input: TokenStream) -> TokenStream {
 /// type is lost in the translation because Elixir has no such concept.
 #[proc_macro_derive(NifUntaggedEnum)]
 pub fn nif_untagged_enum(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_macro_input(&s).unwrap();
-    let gen = untagged_enum::transcoder_decorator(&ast);
-    gen.unwrap().parse().unwrap()
+    let ast = syn::parse(input).unwrap();
+    untagged_enum::transcoder_decorator(&ast).into()
 }

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -1,19 +1,21 @@
-use ::syn::{self, Body, Ident, Variant, VariantData};
-use ::quote::{self, Tokens};
+use proc_macro2::TokenStream;
 
-pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &str> {
-    let variants = match ast.body {
-        Body::Enum(ref variants) => variants,
-        Body::Struct(_) => panic!("NifUntaggedEnum can only be used with enums"),
+use ::syn::{self, Data, Ident, Variant, Fields};
+
+pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
+    let variants = match ast.data {
+        Data::Enum(ref data_enum) => &data_enum.variants,
+        Data::Struct(_) => panic!("NifUntaggedEnum can only be used with enums"),
+        Data::Union(_) => panic!("NifUntaggedEnum can only be used with enums"),
     };
 
-    let num_lifetimes = ast.generics.lifetimes.len();
+    let num_lifetimes = ast.generics.lifetimes().count();
     if num_lifetimes > 1 { panic!("Enum can only have one lifetime argument"); }
     let has_lifetime = num_lifetimes == 1;
 
     for variant in variants {
-        if let VariantData::Tuple(ref fields) = variant.data {
-            if fields.len() != 1 {
+        if let Fields::Unnamed(_) = variant.fields {
+            if variant.fields.iter().count() != 1 {
                 panic!("NifUntaggedEnum can only be used with enums that contain all NewType variants.");
             }
         } else {
@@ -21,25 +23,29 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> Result<quote::Tokens, &st
         }
     }
 
-    let decoder = gen_decoder(&ast.ident, variants, has_lifetime);
-    let encoder = gen_encoder(&ast.ident, variants, has_lifetime);
+    let variants: Vec<&Variant> = variants.iter().collect();
 
-    Ok(quote! {
+    let decoder = gen_decoder(&ast.ident, &variants, has_lifetime);
+    let encoder = gen_encoder(&ast.ident, &variants, has_lifetime);
+
+    let gen = quote!{
         #decoder
         #encoder
-    })
+    };
+
+    gen.into()
 }
 
-pub fn gen_decoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) -> Tokens {
+pub fn gen_decoder(enum_name: &Ident, variants: &[&Variant], has_lifetime: bool) -> TokenStream {
     let enum_type = if has_lifetime {
         quote! { #enum_name <'b> }
     } else {
         quote! { #enum_name }
     };
 
-    let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
-        let variant_name = variant.ident.clone();
-        let field_type   = variant.data.fields()[0].ty.clone();
+    let variant_defs: Vec<_> = variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
+        let field_type   = &variant.fields.iter().next().unwrap().ty;
 
         quote! {
             if let Ok(inner) = #field_type::decode(term) {
@@ -48,7 +54,7 @@ pub fn gen_decoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) 
         }
     }).collect();
 
-    quote! {
+    let gen = quote! {
         impl<'a> ::rustler::Decoder<'a> for #enum_type {
             fn decode(term: ::rustler::Term<'a>) -> Result<Self, ::rustler::Error> {
                 #(#variant_defs)*
@@ -56,25 +62,27 @@ pub fn gen_decoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) 
                 Err(::rustler::Error::Atom("invalid_variant"))
             }
         }
-    }
+    };
+
+    gen.into()
 }
 
-pub fn gen_encoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) -> Tokens {
+pub fn gen_encoder(enum_name: &Ident, variants: &[&Variant], has_lifetime: bool) -> TokenStream {
     let enum_type = if has_lifetime {
         quote! { #enum_name <'b> }
     } else {
         quote! { #enum_name }
     };
 
-    let variant_defs: Vec<Tokens> = variants.iter().map(|variant| {
-        let variant_name = variant.ident.clone();
+    let variant_defs: Vec<_> = variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
 
         quote! {
             #enum_name :: #variant_name ( ref inner ) => inner.encode(env),
         }
     }).collect();
 
-    quote! {
+    let gen = quote! {
         impl<'b> ::rustler::Encoder for #enum_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 match *self {
@@ -82,5 +90,7 @@ pub fn gen_encoder(enum_name: &Ident, variants: &[Variant], has_lifetime: bool) 
                 }
             }
         }
-    }
+    };
+
+    gen.into()
 }


### PR DESCRIPTION
This pull request bumps the `quote` and `syn` crates to newer versions. As their respective API changed, changes to `rustler_codegen` were necessary (e.g. moving from `Tokens` to `TokenStream`). To simplify using `TokenStream` together with `quote` (e.g. combining multiple `TokenStream` into a single `quote!`), I added `proc_macro2`.