### PR TITLE
Support enif_make_map_from_arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ fn add<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
 }
 ```
 
+#### Supported nif_version
+
+Rustler uses `erlang:system_info(nif_version)` to detect the supported NIF version of the Erlang/OTP
+system for which the NIF is to be compiled. It is possible to restrict the NIF version to an older
+version if the NIF is to be compiled for an older version of Erlang. For example, if the target NIF
+version should be `2.7` (Erlang/OTP 17.3), this can be defined using an environment variable:
+
+```
+RUSTLER_NIF_VERSION=2.7 mix compile
+```
+
 #### Community
 
 You can find us in `#rustler` on [freenode](http://freenode.net/) or [the elixir-lang slack](https://elixir-slackin.herokuapp.com/).

--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -13,6 +13,10 @@ alternative_nif_init_name = []
 erlang_nif-sys = ">=0.6.4"
 lazy_static = "1.0"
 
+[build-dependencies]
+lazy_static = "1.0"
+which = "2"
+
 [package.metadata.release]
 
 [[package.metadata.release.pre-release-replacements]]

--- a/rustler/build.rs
+++ b/rustler/build.rs
@@ -1,0 +1,61 @@
+/// Detect NIF version to build against
+
+use std::env;
+use std::process::Command;
+
+extern crate lazy_static;
+use lazy_static::lazy_static;
+
+extern crate which;
+use which::which;
+
+lazy_static! {
+    // keep this sorted by version number
+    static ref ERTS_VERSIONS: Vec<&'static str> = vec![
+        "2.7", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"
+    ];
+}
+
+fn main() {
+    let version = match env::var("RUSTLER_NIF_VERSION") {
+        Ok(version) => version,
+        Err(_) => get_version_from_erl()
+    };
+
+    activate_versions(&version);
+}
+
+fn get_version_from_erl() -> String {
+    let erl = which("erl").expect("expected to find 'erl' executable");
+    let args = vec![
+        "-noshell",
+        "-eval",
+        r#"io:format("~s~n", [erlang:system_info(nif_version)]), init:stop()."#
+    ];
+
+    let version = Command::new(erl)
+        .args(&args)
+        .output()
+        .expect("failed to execute 'erl'")
+        .stdout;
+
+    let version = String::from_utf8(version).expect("convert version to String");
+    dbg!(version.clone());
+
+    version.trim().into()
+}
+
+fn activate_versions(version: &str) {
+    let index = ERTS_VERSIONS
+        .iter()
+        .position(|&v| v == version)
+        .expect(&format!("Erlang version {} not handled, please file a a bug report.", version));
+
+    for i in 0..=index {
+        println!("cargo:rustc-cfg=nif_version_{}", version_feature(ERTS_VERSIONS[i]));
+    }
+}
+
+fn version_feature(version: &str) -> String {
+    version.replace(".", "_")
+}

--- a/rustler/src/wrapper/map.rs
+++ b/rustler/src/wrapper/map.rs
@@ -102,3 +102,14 @@ pub unsafe fn map_iterator_get_pair(
 pub unsafe fn map_iterator_next(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
     nif_interface::enif_map_iterator_next(env, iter);
 }
+
+#[cfg(nif_2_14)]
+pub unsafe fn make_map_from_arrays(env: NIF_ENV, keys: &[NIF_TERM], values: &[NIF_TERM]) -> Option<NIF_TERM> {
+    let mut map = mem::uninitialized();
+    if nif_interface::enif_make_map_from_arrays(
+        env, keys.as_ptr(), values.as_ptr(), keys.len() as usize, &mut map) == 0 {
+        return None;
+    }
+
+    Some(map)
+}

--- a/rustler/src/wrapper/nif_interface.rs
+++ b/rustler/src/wrapper/nif_interface.rs
@@ -235,6 +235,17 @@ pub unsafe fn enif_make_map_remove(
     erlang_nif_sys::enif_make_map_remove(env, map_in, key, map_out)
 }
 
+#[cfg(nif_2_14)]
+pub unsafe fn enif_make_map_from_arrays(
+    env: NIF_ENV,
+    keys: *const NIF_TERM,
+    value: *const NIF_TERM,
+    cnt: size_t,
+    map_out: *mut NIF_TERM
+) -> c_int {
+    erlang_nif_sys::enif_make_map_from_arrays(env, keys, value, cnt, map_out)
+}
+
 // Tuple
 pub unsafe fn enif_get_tuple(
     env: NIF_ENV,

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -24,6 +24,7 @@ defmodule RustlerTest do
 
   def sum_map_values(_), do: err()
   def map_entries_sorted(_), do: err()
+  def map_from_arrays(_keys, _values), do: err()
 
   def resource_make(), do: err()
   def resource_set_integer_field(_, _), do: err()

--- a/rustler_tests/src/lib.rs
+++ b/rustler_tests/src/lib.rs
@@ -39,6 +39,7 @@ rustler::rustler_export_nifs!(
 
         ("sum_map_values", 1, test_map::sum_map_values),
         ("map_entries_sorted", 1, test_map::map_entries_sorted),
+        ("map_from_arrays", 2, test_map::map_from_arrays),
 
         ("resource_make", 0, test_resource::resource_make),
         ("resource_set_integer_field", 2, test_resource::resource_set_integer_field),

--- a/rustler_tests/src/test_map.rs
+++ b/rustler_tests/src/test_map.rs
@@ -30,3 +30,10 @@ pub fn map_entries_sorted<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term
         .collect();
     Ok(erlang_pairs.encode(env))
 }
+
+pub fn map_from_arrays<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+    let keys: Vec<Term> = args[0].decode()?;
+    let values: Vec<Term> = args[1].decode()?;
+
+    Term::map_from_arrays(env, &keys, &values)
+}

--- a/rustler_tests/test/map_test.exs
+++ b/rustler_tests/test/map_test.exs
@@ -10,4 +10,11 @@ defmodule RustlerTest.MapTest do
     assert [{"a", 1}, {"b", 7}, {"c", 6}, {"d", 0}, {"e", 4}] ==
       RustlerTest.map_entries_sorted(%{"d" => 0, "a" => 1, "b" => 7, "e" => 4, "c" => 6})
   end
+
+  test "map from arrays" do
+    keys = Enum.into(1..10, [])
+    values = Enum.into(11..20, [])
+    expected_map = Enum.zip(keys, values) |> Enum.into(%{})
+    assert expected_map == RustlerTest.map_from_arrays(keys, values)
+  end
 end


### PR DESCRIPTION
This PR adds support for `enif_make_map_from_arrays`. This requires OTP 21.

Fix #157.