### PR TITLE
Add rustler attributes for conditional compilation

### DIFF
--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -4,19 +4,133 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 extern crate heck;
-extern crate syn;
 extern crate proc_macro2;
+extern crate syn;
 
 #[macro_use]
 extern crate quote;
 
-mod util;
-mod tuple;
-mod record;
-mod map;
+use syn::{Lit, Meta, MetaList, NestedMeta};
+
 mod ex_struct;
+mod map;
+mod record;
+mod tuple;
 mod unit_enum;
 mod untagged_enum;
+mod util;
+
+#[derive(Debug)]
+enum RustlerAttr {
+    Encode,
+    Decode,
+    Module(String),
+    Tag(String),
+}
+
+#[derive(Debug)]
+struct Context {
+    attrs: Vec<RustlerAttr>,
+}
+
+impl Context {
+    fn from_ast(ast: &syn::DeriveInput) -> Self {
+        let mut attrs: Vec<_> = ast
+            .attrs
+            .iter()
+            .filter_map(Context::get_rustler_attrs)
+            .flatten()
+            .collect();
+
+        //
+        // Default: generate encoder and decoder
+        //
+        if !Context::encode_decode_attr_set(&attrs) {
+            attrs.push(RustlerAttr::Encode);
+            attrs.push(RustlerAttr::Decode);
+        }
+
+        Self {
+            attrs
+        }
+    }
+
+    fn encode(&self) -> bool {
+        self.attrs.iter().find(|attr| match attr {
+            RustlerAttr::Encode => true,
+            _ => false
+        }).is_some()
+    }
+
+    fn decode(&self) -> bool {
+        self.attrs.iter().find(|attr| match attr {
+            RustlerAttr::Decode => true,
+            _ => false
+        }).is_some()
+    }
+
+    fn encode_decode_attr_set(attrs: &[RustlerAttr]) -> bool {
+        attrs.iter().find(|attr| match attr {
+            RustlerAttr::Encode => true,
+            RustlerAttr::Decode => true,
+            _ => false
+        }).is_some()
+    }
+
+    fn get_rustler_attrs(attr: &syn::Attribute) -> Option<Vec<RustlerAttr>> {
+        if attr.path.segments.len() == 1 && attr.path.segments[0].ident == "rustler" {
+            let meta = attr.parse_meta().expect("can parse meta");
+            match meta {
+                Meta::List(list) => Some(Context::parse_attribute_list(list)),
+                Meta::Word(word) => {
+                    panic!("Unexpected Ident {}", word);
+                }
+                Meta::NameValue(name_value) => {
+                    panic!("Unexpected name-value {}", name_value.ident);
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn parse_attribute_list(list: MetaList) -> Vec<RustlerAttr> {
+        list.nested
+            .iter()
+            .map(|nested| match nested {
+                NestedMeta::Meta(meta) => match meta.name().to_string().as_ref() {
+                    "encode" => RustlerAttr::Encode,
+                    "decode" => RustlerAttr::Decode,
+                    "module" => match meta {
+                        Meta::NameValue(name_value) => {
+                            let module = match name_value.lit {
+                                Lit::Str(ref module) => module.value(),
+                                _ => panic!("Cannot parse module"),
+                            };
+                            RustlerAttr::Module(module)
+                        }
+                        _ => panic!("Cannot parse module"),
+                    },
+                    "tag" => match meta {
+                        Meta::NameValue(name_value) => {
+                            let tag = match name_value.lit {
+                                Lit::Str(ref tag) => tag.value(),
+                                _ => panic!("Cannot parse tag"),
+                            };
+                            RustlerAttr::Tag(tag)
+                        }
+                        _ => panic!("Cannot parse tag"),
+                    },
+                    attribute => panic!("Unhandled attribute {}", attribute),
+                },
+                NestedMeta::Literal(lit) => match lit {
+                    Lit::Str(lit_str) => panic!("Unexpected literal {}", lit_str.value()),
+                    _ => panic!("Unexpected literal"),
+                },
+            })
+            .collect()
+    }
+}
 
 /// Implementation of the `NifStruct` macro that lets the user annotate a struct that will
 /// be translated directly from an Elixir struct to a Rust struct. For example, the following
@@ -38,7 +152,7 @@ mod untagged_enum;
 ///     defstruct lhs: 0, rhs: 0
 /// end
 /// ```
-#[proc_macro_derive(NifStruct, attributes(module))]
+#[proc_macro_derive(NifStruct, attributes(module, rustler))]
 pub fn nif_struct(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     ex_struct::transcoder_decorator(&ast).into()
@@ -62,7 +176,7 @@ pub fn nif_struct(input: TokenStream) -> TokenStream {
 /// ```text
 /// %{lhs: 33, rhs: 21}
 /// ```
-#[proc_macro_derive(NifMap)]
+#[proc_macro_derive(NifMap, attributes(rustler))]
 pub fn nif_map(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     map::transcoder_decorator(&ast).into()
@@ -88,7 +202,7 @@ pub fn nif_map(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// The size of the tuple will depend on the number of elements in the struct.
-#[proc_macro_derive(NifTuple)]
+#[proc_macro_derive(NifTuple, attributes(rustler))]
 pub fn nif_tuple(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     tuple::transcoder_decorator(&ast).into()
@@ -115,7 +229,7 @@ pub fn nif_tuple(input: TokenStream) -> TokenStream {
 ///     defrecord :record, [lhs: 1, rhs: 2]
 /// end
 /// ```
-#[proc_macro_derive(NifRecord, attributes(tag))]
+#[proc_macro_derive(NifRecord, attributes(tag, rustler))]
 pub fn nif_record(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     record::transcoder_decorator(&ast).into()
@@ -144,7 +258,7 @@ pub fn nif_record(input: TokenStream) -> TokenStream {
 ///
 /// Note that the `:invalid_variant` atom is returned if the user tries to encode something
 /// that isn't in the Rust enum.
-#[proc_macro_derive(NifUnitEnum)]
+#[proc_macro_derive(NifUnitEnum, attributes(rustler))]
 pub fn nif_unit_enum(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     unit_enum::transcoder_decorator(&ast).into()
@@ -181,7 +295,7 @@ pub fn nif_unit_enum(input: TokenStream) -> TokenStream {
 ///
 /// Note that the type of elixir return is dependent on the data in the enum and the actual enum
 /// type is lost in the translation because Elixir has no such concept.
-#[proc_macro_derive(NifUntaggedEnum)]
+#[proc_macro_derive(NifUntaggedEnum, attributes(rustler))]
 pub fn nif_untagged_enum(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     untagged_enum::transcoder_decorator(&ast).into()

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -2,7 +2,11 @@ use proc_macro2::{Span, TokenStream};
 
 use ::syn::{self, Data, Field, Ident};
 
+use super::Context;
+
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
+    let ctx = Context::from_ast(ast);
+
     let struct_fields = match ast.data {
         Data::Struct(ref data_struct) => &data_struct.fields,
         _ => panic!("Must decorate a struct"),
@@ -32,8 +36,19 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 
     let struct_fields: Vec<_> = struct_fields.iter().collect();
 
-    let decoder = gen_decoder(&ast.ident, &struct_fields, &atom_defs, has_lifetime);
-    let encoder = gen_encoder(&ast.ident, &struct_fields, &atom_defs, has_lifetime);
+    let decoder =
+        if ctx.decode() {
+            gen_decoder(&ast.ident, &struct_fields, &atom_defs, has_lifetime)
+        } else {
+            quote! {}
+        };
+
+    let encoder =
+        if ctx.encode() {
+            gen_encoder(&ast.ident, &struct_fields, &atom_defs, has_lifetime)
+        } else {
+            quote! {}
+        };
 
     let gen = quote! {
         #decoder

--- a/rustler_tests/src/test_codegen.rs
+++ b/rustler_tests/src/test_codegen.rs
@@ -12,6 +12,7 @@ pub fn tuple_echo<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
 }
 
 #[derive(NifRecord)]
+#[rustler(encode, decode)] // Added to check encode/decode attribute, #180
 #[must_use] // Added to check attribute order (see similar issue #152)
 #[tag = "record"]
 struct AddRecord {


### PR DESCRIPTION
This commit adds attributes for conditional code generation of encode and
decode. Users can now choose if they want both encode and decode
functions to be derived, or only one of those functions.

For example, for the following struct `A`, only encode is derived:

```rust
struct A<'a> {
    my_string: &'a str,
}
```

Additionally, this commit also refactors how the module for Elixir
structs or the tag for Erlang records can be set. In addition to the
format `#[module = "A.B.C"]` or `#[tag = "a"]`, the `rustler` attribute
may also be used:

```rust
struct A<'a> {
    my_string: &'a str,
}
```

Fix #180