### PR TITLE
Fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rustler
 
-[Documentation](https://docs.rs/rustler/) | [Getting Started](https://github.com/hansihe/Rustler/blob/master/README.md#getting-started) | [Example](https://github.com/hansihe/NifIo)
+[Documentation](https://docs.rs/crate/rustler) | [Getting Started](https://github.com/hansihe/Rustler/blob/master/README.md#getting-started) | [Example](https://github.com/hansihe/NifIo)
 
 [![Build Status](https://travis-ci.org/hansihe/rustler.svg?branch=master)](https://travis-ci.org/hansihe/rustler)
 


### PR DESCRIPTION
The old link is dead. It should also be fixed in the project description on Github.

```
https://docs.rs/crate/rustler 
```