### PR TITLE
Update lazy_static

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -11,10 +11,10 @@ alternative_nif_init_name = []
 
 [dependencies]
 erlang_nif-sys = ">=0.6.4"
-lazy_static = "1.0"
+lazy_static = "1.2"
 
 [build-dependencies]
-lazy_static = "1.0"
+lazy_static = "1.2"
 which = "2"
 
 [package.metadata.release]


### PR DESCRIPTION
```
λ rustc -V
rustc 1.32.0 (9fda7c223 2019-01-16)
```

Without this change I was unable to run `cargo test` due to the following errors:

```
error: cannot find macro `__lazy_static_internal!` in this scope
  --> rustler/build.rs:12:1
   |
12 | / lazy_static! {
13 | |     // keep this sorted by version number
14 | |     static ref ERTS_VERSIONS: Vec<&'static str> = vec![
15 | |         "2.7", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"
16 | |     ];
17 | | }
   | |_^
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error[E0425]: cannot find value `ERTS_VERSIONS` in this scope
  --> rustler/build.rs:48:17
   |
48 |     let index = ERTS_VERSIONS
   |                 ^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `ERTS_VERSIONS` in this scope
  --> rustler/build.rs:54:68
   |
54 |         println!("cargo:rustc-cfg=nif_version_{}", version_feature(ERTS_VERSIONS[i]));
   |                                                                    ^^^^^^^^^^^^^ not found in this scope

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0425`.
error: Could not compile `rustler`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```