### PR TITLE
Fix map_from_arrays

### DIFF
--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -25,8 +25,8 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// List.zip(keys, values) |> Map.new()
     /// ```
-    #[cfg(nif_2_14)]
-    pub fn map_from_arrays(env: Env<'a>, keys: &[Term], values: &[Term]) -> NifResult<Term<'a>> {
+    #[cfg(nif_version_2_14)]
+    pub fn map_from_arrays(env: Env<'a>, keys: &[Term<'a>], values: &[Term<'a>]) -> NifResult<Term<'a>> {
         let keys: Vec<_> = keys.iter().map(|k| k.as_c_arg()).collect();
         let values: Vec<_> = values.iter().map(|v| v.as_c_arg()).collect();
 
@@ -37,7 +37,7 @@ impl<'a> Term<'a> {
     }
 
     // Fallback for older NIF version
-    #[cfg(not(nif_2_14))]
+    #[cfg(not(nif_version_2_14))]
     pub fn map_from_arrays(env: Env<'a>, keys: &[Term<'a>], values: &[Term<'a>]) -> NifResult<Term<'a>> {
         let map = map_new(env);
         keys.iter().zip(values.iter()).try_fold(map, |map, (k, v)| {

--- a/rustler/src/wrapper/map.rs
+++ b/rustler/src/wrapper/map.rs
@@ -103,7 +103,7 @@ pub unsafe fn map_iterator_next(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
     nif_interface::enif_map_iterator_next(env, iter);
 }
 
-#[cfg(nif_2_14)]
+#[cfg(nif_version_2_14)]
 pub unsafe fn make_map_from_arrays(env: NIF_ENV, keys: &[NIF_TERM], values: &[NIF_TERM]) -> Option<NIF_TERM> {
     let mut map = mem::uninitialized();
     if nif_interface::enif_make_map_from_arrays(

--- a/rustler/src/wrapper/nif_interface.rs
+++ b/rustler/src/wrapper/nif_interface.rs
@@ -235,7 +235,7 @@ pub unsafe fn enif_make_map_remove(
     erlang_nif_sys::enif_make_map_remove(env, map_in, key, map_out)
 }
 
-#[cfg(nif_2_14)]
+#[cfg(nif_version_2_14)]
 pub unsafe fn enif_make_map_from_arrays(
     env: NIF_ENV,
     keys: *const NIF_TERM,


### PR DESCRIPTION
Fixes problem where `enif_make_map_from_arrays` was never being used by `map_from_arrays` because it was behind an invalid `cfg` version.

- Fix cfg to be `nif_version_2_14` instead of `nif_2_14`
- Add missing lifetimes to the keys and values in the type signature